### PR TITLE
Include runtime and workflow outputs in syntax highlighter

### DIFF
--- a/src/main/scala/wdl4s/AstTools.scala
+++ b/src/main/scala/wdl4s/AstTools.scala
@@ -114,9 +114,12 @@ object AstTools {
     val Inputs = "Inputs"
     val MemberAccess = "MemberAccess"
     val Runtime = "Runtime"
+    val RuntimeAttribute = "RuntimeAttribute"
     val Declaration = "Declaration"
     val WorkflowOutput = "WorkflowOutput"
     val Scatter = "Scatter"
+    val Meta = "Meta"
+    val ParameterMeta = "ParameterMeta"
   }
 
   def getAst(wdlSource: WdlSource, resource: String): Ast = {

--- a/src/main/scala/wdl4s/WdlSyntaxErrorFormatter.scala
+++ b/src/main/scala/wdl4s/WdlSyntaxErrorFormatter.scala
@@ -199,9 +199,30 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WdlSource]) extend
   }
 
   def trueAndFalseAttributesAreRequired(firstAttribute: Terminal) = {
-    s"""ERROR: both 'true' and 'false' attributes must be specified if either is specified:
+    s"""ERROR: Both 'true' and 'false' attributes must be specified if either is specified:
        |
        |${pointToSource(firstAttribute)}
+     """.stripMargin
+  }
+
+  def expressionExpectedToBeString(key: Terminal) = {
+    s"""ERROR: Value for this attribute is expected to be a string:
+        |
+       |${pointToSource(key)}
+     """.stripMargin
+  }
+
+  def expectedAtMostOneSectionPerTask(section: String, taskName: Terminal) = {
+    s"""ERROR: Expecting to find at most one '$section' section in the task:
+        |
+       |${pointToSource(taskName)}
+     """.stripMargin
+  }
+
+  def expectedExactlyOneCommandSectionPerTask(taskName: Terminal) = {
+    s"""ERROR: Expecting to find at most one 'command' section in the task:
+        |
+       |${pointToSource(taskName)}
      """.stripMargin
   }
 }

--- a/src/main/scala/wdl4s/formatter/SyntaxFormatter.scala
+++ b/src/main/scala/wdl4s/formatter/SyntaxFormatter.scala
@@ -90,12 +90,36 @@ class SyntaxFormatter(highlighter: SyntaxHighlighter = NullSyntaxHighlighter) {
       case x: Seq[String] if x.nonEmpty => x.mkString("\n")
       case _ => ""
     }
-    val sections = List(declarations, command, outputs).filter(_.nonEmpty)
+    val runtime = formatRuntimeSection(task, 1)
+    val sections = List(declarations, command, outputs, runtime).filter(_.nonEmpty)
     val header = s"""${highlighter.keyword("task")} ${highlighter.name(task.name)} {
        |${sections.mkString("\n")}
        |}"""
      .stripMargin
     header
+  }
+
+  private def formatRuntimeSection(task: Task, level: Int): String = {
+    task.runtimeAttributes.attrs match {
+      case m: Map[String, Seq[String]] if m.nonEmpty =>
+        val attrs = m map { case (k, v) => formatRuntimeAttribute(k, v, 1) }
+        indent(
+          s"""${highlighter.keyword("runtime")} {
+             |${attrs.mkString("\n")}
+             |}""".stripMargin, level)
+      case _ => ""
+    }
+  }
+
+  private def formatRuntimeAttribute(key: String, value: Seq[String], level: Int) = {
+    val rhs = value match {
+      case s: Seq[String] if s.isEmpty => "\"\""
+      case s: Seq[String] if s.size == 1 => "\"" + s.head + "\""
+      case s: Seq[String] =>
+        val stringList = s.map(x => "\"" + x + "\"").mkString(", ")
+        s"[$stringList]"
+    }
+    indent(s"$key: $rhs", level)
   }
 
   private def formatCommandSection(task: Task, level:Int): String = {
@@ -123,11 +147,32 @@ class SyntaxFormatter(highlighter: SyntaxHighlighter = NullSyntaxHighlighter) {
   private def formatWorkflow(workflow: Workflow): String = {
     val declarations = workflow.declarations.map(formatDeclaration(_, 1))
     val children = workflow.children.map(formatScope(_, 1))
-    val sections = (declarations ++ children).filter(_.nonEmpty)
+    val outputs = formatWorkflowOutputs(workflow.workflowOutputDecls, 1)
+    val sections = (declarations ++ children ++ Seq(outputs)).filter(_.nonEmpty)
     s"""${highlighter.keyword("workflow")} ${highlighter.name(workflow.unqualifiedName)} {
         |${sections.mkString("\n")}
         |}""".stripMargin
   }
+
+  private def formatWorkflowOutputs(outputs: Seq[WorkflowOutputDeclaration], level: Int): String = {
+    outputs match {
+      case x: Seq[WorkflowOutputDeclaration] if x.nonEmpty =>
+        val outputStrings = outputs.map(formatWorkflowOutput(_, 1))
+        indent(s"""${highlighter.keyword("output")} {
+                  |${outputStrings.mkString("\n")}
+                  |}""".stripMargin, 1)
+      case _ => ""
+    }
+  }
+
+  private def formatWorkflowOutput(output: WorkflowOutputDeclaration, level: Int): String = {
+    output.wildcard match {
+      case true => indent(s"${formatWorkflowOutputFqn(output.fqn)}.*", level)
+      case false => indent(formatWorkflowOutputFqn(output.fqn), level)
+    }
+  }
+
+  private def formatWorkflowOutputFqn(fqn: String) = fqn.replaceFirst("[a-zA-Z0-9]+\\.", "")
 
   private def formatDeclaration(decl: Declaration, level: Int): String = {
     val expression = decl.expression.map(e => s" = ${e.toWdlString}").getOrElse("")

--- a/src/test/scala/wdl4s/SyntaxErrorSpec.scala
+++ b/src/test/scala/wdl4s/SyntaxErrorSpec.scala
@@ -256,5 +256,34 @@ class SyntaxErrorSpec extends FlatSpec with Matchers {
         |}
       """.stripMargin)
   }
+  it should "detect when a meta or parameter_meta value is not a string" in {
+    expectError(
+      """task a {
+        |  command { ./script }
+        |  output {
+        |    Int x = "bad value"
+        |  }
+        |  meta {
+        |    foo: 1+1
+        |  }
+        |}
+        |
+        |workflow w {
+        |  call a
+        |}
+      """.stripMargin)
+  }
+  it should "detect when a two command sections are specified" in {
+    expectError(
+      """task a {
+        |  command { ./script }
+        |  command { ps }
+        |}
+        |
+        |workflow w {
+        |  call a
+        |}
+      """.stripMargin)
+  }
 }
 

--- a/src/test/scala/wdl4s/SyntaxHighlightSpec.scala
+++ b/src/test/scala/wdl4s/SyntaxHighlightSpec.scala
@@ -5,6 +5,45 @@ import org.scalatest.{Matchers, WordSpecLike}
 
 class SyntaxHighlightSpec extends Matchers with WordSpecLike {
 
+  "foo" should {
+    "bar" in {
+      val namespace = WdlNamespace.load(
+        """task t {
+          |  String f
+          |  Int p
+          |  command {
+          |    ./cmd ${f} ${p}
+          |  }
+          |  runtime {
+          |    docker: "broadinstitute/blah"
+          |  }
+          |}
+          |
+          |workflow w {
+          |  Array[String] a = ["foo", "bar", "baz"]
+          |  call t
+          |  call t as u {
+          |    input: f="abc", p=2
+          |  }
+          |  scatter (b in a) {
+          |    call t as v {
+          |      input: f=t, p=3
+          |    }
+          |  }
+          |  output {
+          |    t.p
+          |    t.f
+          |  }
+          |}
+        """.stripMargin
+      )
+      val ansi = new SyntaxFormatter(AnsiSyntaxHighlighter).format(namespace)
+      val html = new SyntaxFormatter(HtmlSyntaxHighlighter).format(namespace)
+      println(ansi)
+      println(html)
+    }
+  }
+
   "SyntaxFormatter for simple workflow" should {
     val namespace = WdlNamespace.load(
       """task t {
@@ -13,7 +52,11 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |  command {
         |    ./cmd ${f} ${p}
         |  }
+        |  runtime {
+        |    docker: "broadinstitute/blah"
+        |  }
         |}
+        |
         |workflow w {
         |  Array[String] a = ["foo", "bar", "baz"]
         |  call t
@@ -25,6 +68,10 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |      input: f=t, p=3
         |    }
         |  }
+        |  output {
+        |    t.p
+        |    t.f
+        |  }
         |}
       """.stripMargin
     )
@@ -35,6 +82,9 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |  \u001b[38;5;33mInt\u001b[0m \u001b[38;5;112mp\u001b[0m
         |  \u001b[38;5;214mcommand\u001b[0m {
         |    ./cmd ${f} ${p}
+        |  }
+        |  \u001b[38;5;214mruntime\u001b[0m {
+        |    docker: "broadinstitute/blah"
         |  }
         |}
         |
@@ -49,6 +99,10 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |      input: f=t, p=3
         |    }
         |  }
+        |  \u001b[38;5;214moutput\u001b[0m {
+        |    t.p
+        |    t.f
+        |  }
         |}""".stripMargin
 
     val html =
@@ -57,6 +111,9 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |  <span class="type">Int</span> <span class="variable">p</span>
         |  <span class="section">command</span> {
         |    <span class="command">./cmd ${f} ${p}</span>
+        |  }
+        |  <span class="keyword">runtime</span> {
+        |    docker: "broadinstitute/blah"
         |  }
         |}
         |
@@ -70,6 +127,10 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |    <span class="keyword">call</span> <span class="name">t</span> as <span class="alias">v</span> {
         |      input: f=t, p=3
         |    }
+        |  }
+        |  <span class="keyword">output</span> {
+        |    t.p
+        |    t.f
         |  }
         |}""".stripMargin
 

--- a/src/test/scala/wdl4s/SyntaxHighlightSpec.scala
+++ b/src/test/scala/wdl4s/SyntaxHighlightSpec.scala
@@ -4,46 +4,6 @@ import wdl4s.formatter.{AnsiSyntaxHighlighter, HtmlSyntaxHighlighter, SyntaxForm
 import org.scalatest.{Matchers, WordSpecLike}
 
 class SyntaxHighlightSpec extends Matchers with WordSpecLike {
-
-  "foo" should {
-    "bar" in {
-      val namespace = WdlNamespace.load(
-        """task t {
-          |  String f
-          |  Int p
-          |  command {
-          |    ./cmd ${f} ${p}
-          |  }
-          |  runtime {
-          |    docker: "broadinstitute/blah"
-          |  }
-          |}
-          |
-          |workflow w {
-          |  Array[String] a = ["foo", "bar", "baz"]
-          |  call t
-          |  call t as u {
-          |    input: f="abc", p=2
-          |  }
-          |  scatter (b in a) {
-          |    call t as v {
-          |      input: f=t, p=3
-          |    }
-          |  }
-          |  output {
-          |    t.p
-          |    t.f
-          |  }
-          |}
-        """.stripMargin
-      )
-      val ansi = new SyntaxFormatter(AnsiSyntaxHighlighter).format(namespace)
-      val html = new SyntaxFormatter(HtmlSyntaxHighlighter).format(namespace)
-      println(ansi)
-      println(html)
-    }
-  }
-
   "SyntaxFormatter for simple workflow" should {
     val namespace = WdlNamespace.load(
       """task t {
@@ -54,6 +14,15 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |  }
         |  runtime {
         |    docker: "broadinstitute/blah"
+        |  }
+        |	parameter_meta {
+        |    memory_mb: "Amount of memory to allocate to the JVM"
+        |    param: "Some arbitrary parameter"
+        |    sample_id: "The ID of the sample in format foo_bar_baz"
+        |  }
+        |  meta {
+        |    author: "Joe Somebody"
+        |    email: "joe@company.org"
         |  }
         |}
         |
@@ -72,8 +41,7 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |    t.p
         |    t.f
         |  }
-        |}
-      """.stripMargin
+        |}""".stripMargin
     )
 
     val console =
@@ -85,6 +53,15 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |  }
         |  \u001b[38;5;214mruntime\u001b[0m {
         |    docker: "broadinstitute/blah"
+        |  }
+        |  \u001b[38;5;214mmeta\u001b[0m {
+        |    author: "Joe Somebody"
+        |    email: "joe@company.org"
+        |  }
+        |  \u001b[38;5;214mparameter_meta\u001b[0m {
+        |    memory_mb: "Amount of memory to allocate to the JVM"
+        |    param: "Some arbitrary parameter"
+        |    sample_id: "The ID of the sample in format foo_bar_baz"
         |  }
         |}
         |
@@ -114,6 +91,15 @@ class SyntaxHighlightSpec extends Matchers with WordSpecLike {
         |  }
         |  <span class="keyword">runtime</span> {
         |    docker: "broadinstitute/blah"
+        |  }
+        |  <span class="keyword">meta</span> {
+        |    author: "Joe Somebody"
+        |    email: "joe@company.org"
+        |  }
+        |  <span class="keyword">parameter_meta</span> {
+        |    memory_mb: "Amount of memory to allocate to the JVM"
+        |    param: "Some arbitrary parameter"
+        |    sample_id: "The ID of the sample in format foo_bar_baz"
         |  }
         |}
         |


### PR DESCRIPTION
* Wire through the `meta` and `parameter_meta` sections into the `Task` class
* Add syntax highlighting / code fromatting for workflow outputs, runtime section, meta section, parameter_meta section