### PR TITLE
Add new syntax error for when command references variable that doesn't exist

### DIFF
--- a/src/main/scala/wdl4s/AstTools.scala
+++ b/src/main/scala/wdl4s/AstTools.scala
@@ -18,7 +18,12 @@ object AstTools {
       AstTools.findAstsWithTrail(astNode, name, trail)
     }
     def findTerminalsWithTrail(terminalType: String, trail: Seq[AstNode] = Seq.empty): Map[Terminal, Seq[AstNode]] = {
-      AstTools.findTerminalsWithTrail(astNode, terminalType, trail)
+      astNode match {
+        case a: Ast => a.getAttributes.values.asScala flatMap { _.findTerminalsWithTrail(terminalType, trail :+ a) } toMap
+        case a: AstList => a.asScala.toVector flatMap { _.findTerminalsWithTrail(terminalType, trail :+ a) } toMap
+        case t: Terminal if t.getTerminalStr == terminalType => Map(t -> trail)
+        case _ => Map.empty[Terminal, Seq[AstNode]]
+      }
     }
     def findTopLevelMemberAccesses(): Iterable[Ast] = AstTools.findTopLevelMemberAccesses(astNode)
     def sourceString: String = astNode.asInstanceOf[Terminal].getSourceString
@@ -160,15 +165,6 @@ object AstTools {
       case x: AstList => x.asScala.toVector.flatMap{_.findAstsWithTrail(name, trail :+ x)}.toMap
       case x: Terminal => Map.empty[Ast, Seq[AstNode]]
       case _ => Map.empty[Ast, Seq[AstNode]]
-    }
-  }
-
-  def findTerminalsWithTrail(root: AstNode, name: String, trail: Seq[AstNode] = Seq.empty): Map[Terminal, Seq[AstNode]] = {
-    root match {
-      case a: Ast => a.getAttributes.values.asScala flatMap { _.findTerminalsWithTrail(name, trail :+ a) } toMap
-      case a: AstList => a.asScala.toVector flatMap { _.findTerminalsWithTrail(name, trail :+ a) } toMap
-      case t: Terminal if t.getTerminalStr == name => Map(t -> trail)
-      case _ => Map.empty[Terminal, Seq[AstNode]]
     }
   }
 

--- a/src/main/scala/wdl4s/AstTools.scala
+++ b/src/main/scala/wdl4s/AstTools.scala
@@ -1,6 +1,7 @@
 package wdl4s
 
 import java.io.File
+import scala.language.postfixOps
 
 import wdl4s.types._
 import wdl4s.values._
@@ -13,10 +14,10 @@ import scala.collection.JavaConverters._
 object AstTools {
   implicit class EnhancedAstNode(val astNode: AstNode) extends AnyVal {
     def findAsts(name: String): Seq[Ast] = AstTools.findAsts(astNode, name)
-    def findAstsWithTrail(name: String, trail: Seq[AstNode] = Seq.empty): Map[Ast, Seq[AstNode]] = {
+    def findAstsWithTrail(name: String, trail: Seq[AstNode] = Seq.empty): Map[Ast, Seq[AstNode]] =
       AstTools.findAstsWithTrail(astNode, name, trail)
-    }
-    def findTerminals(): Seq[Terminal] = AstTools.findTerminals(astNode)
+    def findTerminalsWithTrail(terminalType: String, trail: Seq[AstNode] = Seq.empty): Map[Terminal, Seq[AstNode]] =
+      AstTools.findTerminalsWithTrail(astNode, terminalType, trail)
     def findTopLevelMemberAccesses(): Iterable[Ast] = AstTools.findTopLevelMemberAccesses(astNode)
     def sourceString: String = astNode.asInstanceOf[Terminal].getSourceString
     def astListAsVector(): Seq[AstNode] = astNode.asInstanceOf[AstList].asScala.toVector
@@ -157,6 +158,15 @@ object AstTools {
       case x: AstList => x.asScala.toVector.flatMap{_.findAstsWithTrail(name, trail :+ x)}.toMap
       case x: Terminal => Map.empty[Ast, Seq[AstNode]]
       case _ => Map.empty[Ast, Seq[AstNode]]
+    }
+  }
+
+  def findTerminalsWithTrail(root: AstNode, name: String, trail: Seq[AstNode] = Seq.empty): Map[Terminal, Seq[AstNode]] = {
+    root match {
+      case a: Ast => a.getAttributes.values.asScala flatMap { _.findTerminalsWithTrail(name, trail :+ a) } toMap
+      case a: AstList => a.asScala.toVector flatMap { _.findTerminalsWithTrail(name, trail :+ a) } toMap
+      case t: Terminal if t.getTerminalStr == name => Map(t -> trail)
+      case _ => Map.empty[Terminal, Seq[AstNode]]
     }
   }
 

--- a/src/main/scala/wdl4s/AstTools.scala
+++ b/src/main/scala/wdl4s/AstTools.scala
@@ -14,10 +14,12 @@ import scala.collection.JavaConverters._
 object AstTools {
   implicit class EnhancedAstNode(val astNode: AstNode) extends AnyVal {
     def findAsts(name: String): Seq[Ast] = AstTools.findAsts(astNode, name)
-    def findAstsWithTrail(name: String, trail: Seq[AstNode] = Seq.empty): Map[Ast, Seq[AstNode]] =
+    def findAstsWithTrail(name: String, trail: Seq[AstNode] = Seq.empty): Map[Ast, Seq[AstNode]] = {
       AstTools.findAstsWithTrail(astNode, name, trail)
-    def findTerminalsWithTrail(terminalType: String, trail: Seq[AstNode] = Seq.empty): Map[Terminal, Seq[AstNode]] =
+    }
+    def findTerminalsWithTrail(terminalType: String, trail: Seq[AstNode] = Seq.empty): Map[Terminal, Seq[AstNode]] = {
       AstTools.findTerminalsWithTrail(astNode, terminalType, trail)
+    }
     def findTopLevelMemberAccesses(): Iterable[Ast] = AstTools.findTopLevelMemberAccesses(astNode)
     def sourceString: String = astNode.asInstanceOf[Terminal].getSourceString
     def astListAsVector(): Seq[AstNode] = astNode.asInstanceOf[AstList].asScala.toVector

--- a/src/main/scala/wdl4s/WdlExpression.scala
+++ b/src/main/scala/wdl4s/WdlExpression.scala
@@ -185,6 +185,7 @@ object WdlExpression {
 
 case class WdlExpression(ast: AstNode) extends WdlValue {
   override val wdlType = WdlExpressionType
+  import WdlExpression.AstForExpressions
 
   def evaluate(lookup: ScopedLookupFunction, functions: WdlFunctions[WdlValue]): Try[WdlValue] =
     WdlExpression.evaluate(ast, lookup, functions)
@@ -205,6 +206,15 @@ case class WdlExpression(ast: AstNode) extends WdlValue {
 
   def prerequisiteCallNames: Set[LocallyQualifiedName] = this.toMemberAccesses map { _.lhs }
   def toMemberAccesses: Set[MemberAccess] = AstTools.findTopLevelMemberAccesses(ast) map { MemberAccess(_) } toSet
+  def variableReferences: Iterable[Terminal] = {
+    AstTools.findTerminalsWithTrail(ast, "identifier") flatMap { case (terminal, trail) =>
+      // function calls have 'identifier' terminals to represent the name of the function
+      if (trail.nonEmpty && trail.last.isInstanceOf[Ast] && trail.last.asInstanceOf[Ast].isFunctionCall)
+        None
+      else
+        Option(terminal)
+    }
+  }
 }
 
 case object NoLookup extends ScopedLookupFunction {

--- a/src/main/scala/wdl4s/WdlExpression.scala
+++ b/src/main/scala/wdl4s/WdlExpression.scala
@@ -207,7 +207,7 @@ case class WdlExpression(ast: AstNode) extends WdlValue {
   def prerequisiteCallNames: Set[LocallyQualifiedName] = this.toMemberAccesses map { _.lhs }
   def toMemberAccesses: Set[MemberAccess] = AstTools.findTopLevelMemberAccesses(ast) map { MemberAccess(_) } toSet
   def variableReferences: Iterable[Terminal] = {
-    AstTools.findTerminalsWithTrail(ast, "identifier") flatMap { case (terminal, trail) =>
+    ast.findTerminalsWithTrail("identifier") flatMap { case (terminal, trail) =>
       // function calls have 'identifier' terminals to represent the name of the function
       if (trail.nonEmpty && trail.last.isInstanceOf[Ast] && trail.last.asInstanceOf[Ast].isFunctionCall)
         None

--- a/src/main/scala/wdl4s/WdlSyntaxErrorFormatter.scala
+++ b/src/main/scala/wdl4s/WdlSyntaxErrorFormatter.scala
@@ -207,22 +207,57 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WdlSource]) extend
 
   def expressionExpectedToBeString(key: Terminal) = {
     s"""ERROR: Value for this attribute is expected to be a string:
-        |
+       |
        |${pointToSource(key)}
      """.stripMargin
   }
 
   def expectedAtMostOneSectionPerTask(section: String, taskName: Terminal) = {
     s"""ERROR: Expecting to find at most one '$section' section in the task:
-        |
+       |
        |${pointToSource(taskName)}
      """.stripMargin
   }
 
   def expectedExactlyOneCommandSectionPerTask(taskName: Terminal) = {
     s"""ERROR: Expecting to find at most one 'command' section in the task:
-        |
+       |
        |${pointToSource(taskName)}
+     """.stripMargin
+  }
+
+  def commandExpressionContainsInvalidVariableReference(taskName: Terminal, variable: Terminal) = {
+    s"""ERROR: Variable does not reference any declaration in the task (line ${variable.getLine}, col ${variable.getColumn}):
+        |
+        |${pointToSource(variable)}
+        |
+        |Task defined here (line ${taskName.getLine}, col ${taskName.getColumn}):
+        |
+        |${pointToSource(taskName)}
+     """.stripMargin
+  }
+
+  def declarationContainsInvalidVariableReference(declarationName: Terminal, variable: Terminal) = {
+    s"""ERROR: Variable does not reference any declaration in the task (line ${variable.getLine}, col ${variable.getColumn}):
+        |
+        |${pointToSource(variable)}
+        |
+        |Declaration starts here (line ${declarationName.getLine}, col ${declarationName.getColumn}):
+        |
+        |${pointToSource(declarationName)}
+     """.stripMargin
+  }
+
+  def variableDeclaredMultipleTimes(first: Terminal, second: Terminal) = {
+    s"""ERROR: Variable '${first.getSourceString}' is declared more than once.
+        |
+        |First occurrence (line ${first.getLine}, col ${first.getColumn}):
+        |
+        |${pointToSource(first)}
+        |
+        |Second occurrence (line ${second.getLine}, col ${second.getColumn}):
+        |
+        |${pointToSource(second)}
      """.stripMargin
   }
 }


### PR DESCRIPTION
This WDL file:

```
task a {
  Int x
  command { ./script ${x+y} }
}

workflow w {
  call a
}
```

Gives this syntax error:

```
ERROR: Variable does not reference any declaration in the task (line 3, col 26):

  command { ./script ${x+y} }
                         ^

Task defined here (line 1, col 6):

task a {
     ^
```

This WDL:

```
task a {
  Int x
  Int y = x + z
  command { ./script ${x} }
}

workflow w {
  call a {input: x=5}
}
```

Will produce this error:

```
ERROR: Variable does not reference any declaration in the task (line 3, col 15):

  Int y = x + z
              ^

Declaration starts here (line 3, col 7):

  Int y = x + z
      ^
```