### PR TITLE
Scoped declarations

### DIFF
--- a/src/main/scala/wdl4s/Declaration.scala
+++ b/src/main/scala/wdl4s/Declaration.scala
@@ -5,9 +5,8 @@ import wdl4s.types.WdlType
 import wdl4s.parser.WdlParser.{Ast, AstNode}
 
 object Declaration {
-  def apply(ast: Ast, scopeFqn: FullyQualifiedName, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Declaration = {
-    Declaration(
-      scopeFqn,
+  def apply(ast: Ast, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Declaration = {
+    UnscopedDeclaration(
       ast.getAttribute("type").wdlType(wdlSyntaxErrorFormatter),
       Option(ast.getAttribute("postfix")).map(_.sourceString),
       ast.getAttribute("name").sourceString,
@@ -34,16 +33,34 @@ object Declaration {
  *
  * Both the definition of test_file and wf_string are declarations
  */
-case class Declaration(scopeFqn: FullyQualifiedName, wdlType: WdlType, postfixQuantifier: Option[String], name: String, expression: Option[WdlExpression]) {
+trait Declaration {
+  def wdlType: WdlType
+  def postfixQuantifier: Option[String]
+  def name: String
+  def expression: Option[WdlExpression]
+  def asTaskInput: Option[TaskInput] = expression match {
+    case Some(expr) => None
+    case None => Option(TaskInput(name, wdlType, postfixQuantifier))
+  }
+
+  def toWdlString: String = {
+    val expr = expression.map(e => s" = ${e.toWdlString}").getOrElse("")
+    s"${wdlType.toWdlString} $name$expr"
+  }
+}
+
+case class UnscopedDeclaration(wdlType: WdlType, postfixQuantifier: Option[String], name: String, expression: Option[WdlExpression]) extends Declaration
+
+object ScopedDeclaration {
+  def apply(scope: Scope, decl: Declaration): ScopedDeclaration = {
+    ScopedDeclaration(scope, decl.wdlType, decl.postfixQuantifier, decl.name, decl.expression)
+  }
+}
+
+case class ScopedDeclaration(scope: Scope, wdlType: WdlType, postfixQuantifier: Option[String], name: String, expression: Option[WdlExpression]) extends Declaration {
+  def fullyQualifiedName: FullyQualifiedName = s"${scope.fullyQualifiedName}.$name"
   def asWorkflowInput: Option[WorkflowInput] = expression match {
     case Some(expr) => None
     case None => Some(WorkflowInput(fullyQualifiedName, wdlType, postfixQuantifier))
   }
-
-  def asTaskInput: Option[TaskInput] = expression match {
-    case Some(expr) => None
-    case None => Some(TaskInput(name, wdlType, postfixQuantifier))
-  }
-
-  def fullyQualifiedName: FullyQualifiedName = s"$scopeFqn.$name"
 }

--- a/src/main/scala/wdl4s/Task.scala
+++ b/src/main/scala/wdl4s/Task.scala
@@ -4,26 +4,37 @@ import java.util.regex.Pattern
 
 import wdl4s.AstTools.{AstNodeName, EnhancedAstNode}
 import wdl4s.command.{CommandPart, ParameterCommandPart, StringCommandPart}
-import wdl4s.expression.WdlFunctions
+import wdl4s.expression.{NoFunctions, WdlStandardLibraryFunctionsType, WdlFunctions}
 import wdl4s.parser.WdlParser._
+import wdl4s.types.{WdlIntegerType, WdlType}
 import wdl4s.values.WdlValue
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object Task {
   val Ws = Pattern.compile("[\\ \\t]+")
+
+  /** The function validateDeclaration() and the DeclarationAccumulator class are used
+    * to accumulate errors and keep track of which Declarations/TaskOutputs have been examined.
+    *
+    * We're using this approach instead of a scalaz ValidationNel because we still want to
+    * accumulate Declarations even if there was an error with that particular
+    * Declaration
+    */
+  case class DeclarationAccumulator(errors: Seq[String] = Seq.empty, declarations: Seq[Declaration] = Seq.empty)
+
   def apply(ast: Ast, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Task = {
     val taskNameTerminal = ast.getAttribute("name").asInstanceOf[Terminal]
     val name = taskNameTerminal.sourceString
-    val declarations = ast.findAsts(AstNodeName.Declaration).map(Declaration(_, "name", wdlSyntaxErrorFormatter))
+    val declarations = ast.findAsts(AstNodeName.Declaration).map(Declaration(_, wdlSyntaxErrorFormatter))
     val commandAsts = ast.findAsts(AstNodeName.Command)
     val runtimeAttributes = RuntimeAttributes(ast)
     val meta = wdlSectionToStringMap(ast, AstNodeName.Meta, wdlSyntaxErrorFormatter)
     val parameterMeta = wdlSectionToStringMap(ast, AstNodeName.ParameterMeta, wdlSyntaxErrorFormatter)
-    val outputs = ast.findAsts(AstNodeName.Output) map { TaskOutput(_, declarations, wdlSyntaxErrorFormatter) }
+    val outputs = ast.findAsts(AstNodeName.Output) map { TaskOutput(_, wdlSyntaxErrorFormatter) }
 
     if (commandAsts.size != 1) throw new SyntaxError(wdlSyntaxErrorFormatter.expectedExactlyOneCommandSectionPerTask(taskNameTerminal))
     val commandTemplate = commandAsts.head.getAttribute("parts").asInstanceOf[AstList].asScala.toVector map {
@@ -42,110 +53,100 @@ object Task {
       }
     }
 
-    /** The below functions, validateDeclaration and validateOutput use the following case classes
-      * to accumulate errors and keep track of which Declarations/TaskOutputs have been examined.
-      *
-      * We're using this approach instead of a scalaz ValidationNel because we still want to
-      * accumulate Declarations/TaskOutputs even if there was an error with that particular
-      * Declaration/TaskOutput
-      */
-    case class DeclarationAccumulator(errors: Seq[String] = Seq.empty, declarations: Seq[Declaration] = Seq.empty)
-    case class TaskOutputAccumulator(errors: Seq[String] = Seq.empty, taskOutputs: Seq[TaskOutput] = Seq.empty)
+    val declarationErrors = (declarations ++ outputs).foldLeft(DeclarationAccumulator())(validateDeclaration(ast, wdlSyntaxErrorFormatter))
 
-    /**
-      * Ensures that the current declaration doesn't have a name conflict with another declaration
-      * and that the expression for the current declaration only has valid variable references in it
-      *
-      * @param accumulated The declarations that come lexically before 'current' as well
-      *                    as the accumulated errors up until this point
-      * @param current The declaration being validated
-      */
-    def validateDeclaration(accumulated: DeclarationAccumulator, current: Declaration): DeclarationAccumulator = {
-      val variableReferences = for (expr <- current.expression.toIterable; variable <- expr.variableReferences) yield variable
-      val declarationAstsWithSameName = ast.findAsts(AstNodeName.Declaration) collect {
-        case a: Ast if a.getAttribute("name").sourceString == current.name => a
-      }
-
-      val multipleDeclarationsError = declarationAstsWithSameName match {
-        case x if x.size > 1 =>
-          val declNameTerminals = declarationAstsWithSameName.map(_.getAttribute("name").asInstanceOf[Terminal])
-          Some(wdlSyntaxErrorFormatter.variableDeclaredMultipleTimes(declNameTerminals(0), declNameTerminals(1)))
-        case _ => None
-      }
-
-      val invalidVariableReferenceErrors = variableReferences flatMap { variable =>
-        if (!accumulated.declarations.map(_.name).contains(variable.getSourceString)) {
-          // .head below because we are assuming if you have a Declaration object that it must have come from a Declaration AST
-          Option(wdlSyntaxErrorFormatter.declarationContainsInvalidVariableReference(
-            declarationAstsWithSameName.head.getAttribute("name").asInstanceOf[Terminal],
-            variable
-          ))
-        } else {
-          None
-        }
-      }
-
-      DeclarationAccumulator(
-        accumulated.errors ++ multipleDeclarationsError.toSeq ++ invalidVariableReferenceErrors.toSeq,
-        accumulated.declarations :+ current
-      )
-    }
-
-    /**
-      * Ensures that each task output is uniquely named and that all variables
-      * referenced in the expression refer to valid declarations or other task outputs
-      *
-      * @param accumulated All task outputs declared lexically before 'current' as well
-      *                    as the accumulated errors up until this point
-      * @param current The TaskOutput to validate
-      */
-    def validateOutput(accumulated: TaskOutputAccumulator, current: TaskOutput): TaskOutputAccumulator = {
-      val declarationAstsWithSameName = ast.findAsts(AstNodeName.Declaration) collect {
-        case a: Ast if a.getAttribute("name").sourceString == current.name => a
-      }
-      val taskOutputAstsWithSameName = ast.findAsts(AstNodeName.Output) collect {
-        case a: Ast if a.getAttribute("var").sourceString == current.name => a
-      }
-      val outputNameTerminals = taskOutputAstsWithSameName.map(_.getAttribute("var").asInstanceOf[Terminal])
-      val declNameTerminals = declarationAstsWithSameName.map(_.getAttribute("name").asInstanceOf[Terminal])
-
-      val duplicateTaskOutputError = taskOutputAstsWithSameName match {
-        case x if x.size > 1 => Option(wdlSyntaxErrorFormatter.variableDeclaredMultipleTimes(outputNameTerminals(0), outputNameTerminals(1)))
-        case _ => None
-      }
-
-      val declarationHasSameNameError = declarationAstsWithSameName match {
-        case x if x.nonEmpty => Option(wdlSyntaxErrorFormatter.variableDeclaredMultipleTimes(declNameTerminals(0), outputNameTerminals(0)))
-        case _ => None
-      }
-
-      val invalidVariableReferenceErrors = current.expression.variableReferences flatMap { variable =>
-        val varName = variable.getSourceString
-        if (!accumulated.taskOutputs.map(_.name).contains(varName) && !declarations.map(_.name).contains(varName)) {
-          Option(wdlSyntaxErrorFormatter.declarationContainsInvalidVariableReference(
-            taskOutputAstsWithSameName.head.getAttribute("var").asInstanceOf[Terminal],
-            variable
-          ))
-        } else {
-          None
-        }
-      }
-
-      TaskOutputAccumulator(
-        accumulated.errors ++ duplicateTaskOutputError.toSeq ++ declarationHasSameNameError.toSeq ++ invalidVariableReferenceErrors.toSeq,
-        accumulated.taskOutputs :+ current
-      )
-    }
-
-    val declarationErrors = declarations.foldLeft(DeclarationAccumulator())(validateDeclaration)
-    val outputErrors = outputs.foldLeft(TaskOutputAccumulator())(validateOutput)
-
-    declarationErrors.errors ++ outputErrors.errors match {
+    declarationErrors.errors match {
       case x if x.nonEmpty => throw new SyntaxError(x.mkString(s"\n${"-" * 50}\n\n"))
       case _ =>
     }
 
     Task(name, declarations, commandTemplate, runtimeAttributes, meta, parameterMeta, outputs, ast)
+  }
+
+  /**
+    * Ensures that the current declaration doesn't have a name conflict with another declaration
+    * and that the expression for the current declaration only has valid variable references in it
+    *
+    * @param accumulated The declarations that come lexically before 'current' as well
+    *                    as the accumulated errors up until this point
+    * @param current The declaration being validated
+    */
+  private def validateDeclaration(taskAst: Ast, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter)
+                                 (accumulated: DeclarationAccumulator, current: Declaration): DeclarationAccumulator = {
+    val variableReferences = for (expr <- current.expression.toIterable; variable <- expr.variableReferences) yield variable
+    val declarationAstsWithSameName = taskAst.findAsts(AstNodeName.Declaration) collect {
+      case a: Ast if a.getAttribute("name").sourceString == current.name => a
+    }
+    val taskOutputAstsWithSameName = taskAst.findAsts(AstNodeName.Output) collect {
+      case a: Ast if a.getAttribute("var").sourceString == current.name => a
+    }
+
+    val declNameTerminals = declarationAstsWithSameName.map(_.getAttribute("name").asInstanceOf[Terminal]) ++
+                            taskOutputAstsWithSameName.map(_.getAttribute("var").asInstanceOf[Terminal])
+
+    val duplicateDeclarationError = declNameTerminals match {
+      case terminals if terminals.size > 1 => Option(wdlSyntaxErrorFormatter.variableDeclaredMultipleTimes(terminals(0), terminals(1)))
+      case _ => None
+    }
+
+    val invalidVariableReferenceErrors = variableReferences flatMap { variable =>
+      if (!accumulated.declarations.map(_.name).contains(variable.getSourceString)) {
+        // .head below because we are assuming if you have a Declaration object that it must have come from a Declaration AST
+        Option(wdlSyntaxErrorFormatter.declarationContainsInvalidVariableReference(
+          declarationAstsWithSameName.head.getAttribute("name").asInstanceOf[Terminal],
+          variable
+        ))
+      } else {
+        None
+      }
+    }
+
+    val typeErrors = (invalidVariableReferenceErrors, current.expression) match {
+      case (Nil, Some(expr)) => typeCheckExpression(
+        expr, current.wdlType, accumulated.declarations, declNameTerminals.head, wdlSyntaxErrorFormatter
+      )
+      case _ => None
+    }
+
+    DeclarationAccumulator(
+      accumulated.errors ++ duplicateDeclarationError.toSeq ++ invalidVariableReferenceErrors.toSeq ++ typeErrors.toSeq,
+      accumulated.declarations :+ current
+    )
+  }
+
+  /** Validates that `expr`, which is assumed to come from a Declaration, is compatible with
+    * `expectedType`.  If not, a string error message will be returned.
+    *
+    * @param expr Expression to be validated
+    * @param expectedType The type ascription of the declaration
+    * @param priorDeclarations Declarations that come lexically before
+    * @param declNameTerminal The Terminal that represents the name of the variable in the
+    *                         declaration that `expr` comes from.
+    * @param wdlSyntaxErrorFormatter A syntax error formatter in case an error was found.
+    * @return Some(String) if an error occurred where the String is the error message, otherwise None
+    */
+  private def typeCheckExpression(expr: WdlExpression, expectedType: WdlType, priorDeclarations: Seq[Declaration],
+                                  declNameTerminal: Terminal, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Option[String] = {
+
+    // .get below because lookup functions should throw exceptions if they could not lookup the variable
+    def lookupType(n: String) = priorDeclarations.find(_.name == n).map(_.wdlType).get
+
+    expr.evaluateType(lookupType, new WdlStandardLibraryFunctionsType) match {
+      case Success(expressionWdlType) if !expectedType.isCoerceableFrom(expressionWdlType) =>
+        Option(wdlSyntaxErrorFormatter.taskOutputExpressionTypeDoesNotMatchDeclaredType(
+          declNameTerminal, expressionWdlType, expectedType
+        ))
+      case Success(wdlType) =>
+        expr.evaluate((s: String) => throw new Throwable("not implemented"), NoFunctions) match {
+          case Success(value) if expectedType.coerceRawValue(value).isFailure =>
+            Option(wdlSyntaxErrorFormatter.declarationExpressionNotCoerceableToTargetType(
+              declNameTerminal, expectedType
+            ))
+          case _ => None
+        }
+      case Failure(ex) =>
+        Option(wdlSyntaxErrorFormatter.failedToDetermineTypeOfDeclaration(declNameTerminal))
+    }
   }
 
   private def wdlSectionToStringMap(taskAst: Ast, node: String, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Map[String, String] = {
@@ -192,15 +193,6 @@ case class Task(name: String,
                 outputs: Seq[TaskOutput],
                 ast: Ast) extends Executable {
   import Task._
-
-  /**
-   * Inputs to this task, as locally qualified names
-   *
-   * @return Seq[TaskInput] where TaskInput contains the input
-   *         name & type as well as any postfix quantifiers (?, +)
-   */
-  val inputs: Seq[TaskInput] = for (declaration <- declarations; input <- declaration.asTaskInput) yield input
-  // TODO: I think TaskInput can be replaced by Declaration
 
   /**
    * Given a map of task-local parameter names and WdlValues, create a command String.

--- a/src/main/scala/wdl4s/TaskOutput.scala
+++ b/src/main/scala/wdl4s/TaskOutput.scala
@@ -9,34 +9,15 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.util.{Failure, Success}
 
 object TaskOutput extends LazyLogging {
-  def apply(ast: Ast, declarations: Seq[Declaration], syntaxErrorFormatter: WdlSyntaxErrorFormatter): TaskOutput = {
+  def apply(ast: Ast, syntaxErrorFormatter: WdlSyntaxErrorFormatter): TaskOutput = {
     val wdlType = ast.getAttribute("type").wdlType(syntaxErrorFormatter)
     val name = ast.getAttribute("var").sourceString
     val expression = WdlExpression(ast.getAttribute("expression"))
-
-    // .get below because contract with the lookup() function is that it signals
-    // an error by throwing an exception which is wrapped in a Try() in the
-    // evaluator code
-    def lookup(n: String) = declarations.find(_.name == n).get.wdlType
-
-    def badCoercionException(expressionWdlType: WdlType) = throw new SyntaxError(syntaxErrorFormatter.taskOutputExpressionTypeDoesNotMatchDeclaredType(
-      ast.getAttribute("var").asInstanceOf[Terminal],
-      wdlType,
-      expressionWdlType
-    ))
-
-    expression.evaluateType(lookup, new WdlStandardLibraryFunctionsType) match {
-      case Success(expressionWdlType) if !wdlType.isCoerceableFrom(expressionWdlType) => badCoercionException(expressionWdlType)
-      case Success(expressionWdlType) =>
-        val expressionValue = expression.evaluate((s: String) => throw new Throwable("not implemented"), NoFunctions)
-        expressionValue match {
-          case Success(value) if wdlType.coerceRawValue(value).isFailure => badCoercionException(expressionWdlType)
-          case _ =>
-        }
-      case Failure(ex) => logger.error(s"Could not determine type of expression: ${expression.toWdlString}")
-    }
-    new TaskOutput(name, wdlType, expression)
+    TaskOutput(name, wdlType, expression)
   }
 }
 
-case class TaskOutput(name: String, wdlType: WdlType, expression: WdlExpression)
+case class TaskOutput(name: String, wdlType: WdlType, requiredExpression: WdlExpression) extends Declaration {
+  override val postfixQuantifier = None
+  override val expression = Option(requiredExpression)
+}

--- a/src/main/scala/wdl4s/WdlSyntaxErrorFormatter.scala
+++ b/src/main/scala/wdl4s/WdlSyntaxErrorFormatter.scala
@@ -198,6 +198,20 @@ case class WdlSyntaxErrorFormatter(terminalMap: Map[Terminal, WdlSource]) extend
      """.stripMargin
   }
 
+  def declarationExpressionNotCoerceableToTargetType(declName: Terminal, declType: WdlType) = {
+    s"""ERROR: Value for ${declName.getSourceString} is not coerceable into a ${declType.toWdlString}:
+        |
+       |${pointToSource(declName)}
+     """.stripMargin
+  }
+
+  def failedToDetermineTypeOfDeclaration(declName: Terminal) = {
+    s"""ERROR: Could not determine type of declaration ${declName.getSourceString}:
+       |
+       |${pointToSource(declName)}
+     """.stripMargin
+  }
+
   def trueAndFalseAttributesAreRequired(firstAttribute: Terminal) = {
     s"""ERROR: Both 'true' and 'false' attributes must be specified if either is specified:
        |

--- a/src/main/scala/wdl4s/expression/TypeEvaluator.scala
+++ b/src/main/scala/wdl4s/expression/TypeEvaluator.scala
@@ -75,7 +75,7 @@ case class TypeEvaluator(override val lookup: String => WdlType, override val fu
           evaluate(a.getAttribute("lhs")).flatMap {
             case o: WdlCallOutputsObjectType =>
               o.call.task.outputs.find(_.name == rhs.getSourceString) match {
-                case Some(taskOutput) => evaluate(taskOutput.expression.ast)
+                case Some(taskOutput) => evaluate(taskOutput.requiredExpression.ast)
                 case None => Failure(new WdlExpressionException(s"Could not find key ${rhs.getSourceString}"))
               }
             case ns: WdlNamespace => Success(lookup(ns.importedAs.map {n => s"$n.${rhs.getSourceString}"}.getOrElse(rhs.getSourceString)))

--- a/src/main/scala/wdl4s/formatter/SyntaxFormatter.scala
+++ b/src/main/scala/wdl4s/formatter/SyntaxFormatter.scala
@@ -153,7 +153,7 @@ class SyntaxFormatter(highlighter: SyntaxHighlighter = NullSyntaxHighlighter) {
   }
 
   private def formatOutput(output: TaskOutput, level:Int): String = {
-    indent(s"${highlighter.wdlType(output.wdlType)} ${highlighter.variable(output.name)} = ${output.expression.toString(highlighter)}", level)
+    indent(s"${highlighter.wdlType(output.wdlType)} ${highlighter.variable(output.name)} = ${output.requiredExpression.toString(highlighter)}", level)
   }
 
   private def formatWorkflow(workflow: Workflow): String = {

--- a/src/main/scala/wdl4s/util/TryUtil.scala
+++ b/src/main/scala/wdl4s/util/TryUtil.scala
@@ -39,4 +39,9 @@ object TryUtil {
     def unbox = tries map { _.get }
     sequenceIterable(tries, unbox _, prefixErrorMessage)
   }
+
+  def sequenceMap[T, U](tries: Map[T, Try[U]], prefixErrorMessage: String = ""): Try[Map[T, U]] = {
+    def unbox = tries mapValues { _.get }
+    sequenceIterable(tries.values, unbox _, prefixErrorMessage)
+  }
 }

--- a/src/test/scala/wdl4s/DeclarationSpec.scala
+++ b/src/test/scala/wdl4s/DeclarationSpec.scala
@@ -1,0 +1,137 @@
+package wdl4s
+
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.expression.NoFunctions
+import wdl4s.types.WdlStringType
+import wdl4s.values.{WdlInteger, WdlString, WdlValue}
+
+import scala.util.{Success, Failure}
+
+class DeclarationSpec extends FlatSpec with Matchers {
+  val wdlSource = (new SampleWdl.DeclarationsWdl).wdlSource()
+  val namespace = NamespaceWithWorkflow.load(wdlSource)
+
+  "A Workflow with declarations" should "have declarations defined properly" in {
+    namespace.workflow.declarations.size shouldEqual 3
+
+    val foo = namespace.workflow.declarations(0)
+    foo.name shouldEqual "foo"
+    foo.wdlType shouldEqual WdlStringType
+    foo.expression.map(_.toWdlString) shouldEqual Option(""" "foo" """.trim)
+    foo.postfixQuantifier shouldEqual None
+
+    val bar = namespace.workflow.declarations(1)
+    bar.name shouldEqual "bar"
+    bar.wdlType shouldEqual WdlStringType
+    bar.expression.map(_.toWdlString) shouldEqual Option(""" "bar" """.trim)
+    bar.postfixQuantifier shouldEqual None
+
+    val foobar = namespace.workflow.declarations(2)
+    foobar.name shouldEqual "foobar"
+    foobar.wdlType shouldEqual WdlStringType
+    foobar.expression.map(_.toWdlString) shouldEqual Option(""" foo + bar """.trim)
+    foobar.postfixQuantifier shouldEqual None
+  }
+
+  it should "have scoped declarations defined properly" in {
+    namespace.workflow.scopedDeclarations.size shouldEqual 3
+
+    val foo = namespace.workflow.scopedDeclarations(0)
+    foo.scope shouldEqual namespace.workflow
+    foo.fullyQualifiedName shouldEqual "w.foo"
+    foo.toWdlString shouldEqual "String foo = \"foo\""
+
+    val bar = namespace.workflow.scopedDeclarations(1)
+    bar.scope shouldEqual namespace.workflow
+    bar.fullyQualifiedName shouldEqual "w.bar"
+    bar.toWdlString shouldEqual "String bar = \"bar\""
+
+    val foobar = namespace.workflow.scopedDeclarations(2)
+    foobar.scope shouldEqual namespace.workflow
+    foobar.fullyQualifiedName shouldEqual "w.foobar"
+    foobar.toWdlString shouldEqual "String foobar = foo + bar"
+  }
+
+  "A Call with declarations" should "have scoped declarations defined properly" in {
+    val a = namespace.workflow.findCallByName("a").get
+    val aPrime = namespace.workflow.findCallByName("a_prime").get
+    val b = namespace.workflow.findCallByName("b").get
+
+    val aFoo = a.scopedDeclarations(0)
+    aFoo.scope shouldEqual a
+    aFoo.fullyQualifiedName shouldEqual "w.a.foo"
+    aFoo.toWdlString shouldEqual "String foo = \"notfoo\""
+
+    val aBar = a.scopedDeclarations(1)
+    aBar.scope shouldEqual a
+    aBar.fullyQualifiedName shouldEqual "w.a.bar"
+    aBar.toWdlString shouldEqual "String bar = \"bar\""
+
+    val aFooBar = a.scopedDeclarations(2)
+    aFooBar.scope shouldEqual a
+    aFooBar.fullyQualifiedName shouldEqual "w.a.foobar"
+    aFooBar.toWdlString shouldEqual "String foobar = foo + bar"
+
+    val aPrimeFoo = aPrime.scopedDeclarations(0)
+    aPrimeFoo.scope shouldEqual aPrime
+    aPrimeFoo.fullyQualifiedName shouldEqual "w.a_prime.foo"
+    aPrimeFoo.toWdlString shouldEqual "String foo = \"notfoo\""
+
+    val aPrimeBar = aPrime.scopedDeclarations(1)
+    aPrimeBar.scope shouldEqual aPrime
+    aPrimeBar.fullyQualifiedName shouldEqual "w.a_prime.bar"
+    aPrimeBar.toWdlString shouldEqual "String bar = \"bar\""
+
+    val aPrimeFooBar = aPrime.scopedDeclarations(2)
+    aPrimeFooBar.scope shouldEqual aPrime
+    aPrimeFooBar.fullyQualifiedName shouldEqual "w.a_prime.foobar"
+    aPrimeFooBar.toWdlString shouldEqual "String foobar = foo + bar"
+
+    val bFoo = b.scopedDeclarations(0)
+    bFoo.scope shouldEqual b
+    bFoo.fullyQualifiedName shouldEqual "w.b.foo"
+    bFoo.toWdlString shouldEqual "Int foo = 10"
+
+    val bBar = b.scopedDeclarations(1)
+    bBar.scope shouldEqual b
+    bBar.fullyQualifiedName shouldEqual "w.b.bar"
+    bBar.toWdlString shouldEqual "Int bar = 2"
+
+    val bFooBar = b.scopedDeclarations(2)
+    bFooBar.scope shouldEqual b
+    bFooBar.fullyQualifiedName shouldEqual "w.b.foobar"
+    bFooBar.toWdlString shouldEqual "Int foobar = foo + bar"
+
+    val bFooBar2 = b.scopedDeclarations(3)
+    bFooBar2.scope shouldEqual b
+    bFooBar2.fullyQualifiedName shouldEqual "w.b.foobar2"
+    bFooBar2.toWdlString shouldEqual "Int foobar2 = foo + 2"
+  }
+
+  "A workflow" should "Be able to evaluate static declarations" in {
+    namespace.staticDeclarationsRecursive(Map.empty[String, WdlValue], NoFunctions) match {
+      case Failure(ex) => fail("Expected all declarations to be statically evaluatable", ex)
+      case Success(values) =>
+        values shouldEqual Map(
+          "w.foo" -> WdlString("foo"),
+          "w.bar" -> WdlString("bar"),
+          "w.foobar" -> WdlString("foobar"),
+          "w.a.foo" -> WdlString("notfoo"),
+          "w.a.bar" -> WdlString("bar"),
+          "w.a.foobar" -> WdlString("notfoobar"),
+          "w.a_prime.foo" -> WdlString("notfoo"),
+          "w.a_prime.bar" -> WdlString("bar"),
+          "w.a_prime.foobar" -> WdlString("notfoobar"),
+          "w.b.foo" -> WdlInteger(10),
+          "w.b.bar" -> WdlInteger(2),
+          "w.b.foobar" -> WdlInteger(12),
+          "w.b.foobar2" -> WdlInteger(12)
+        )
+    }
+  }
+
+  "A namespace" should "Be able to coerce inputs" in {
+    namespace.coerceRawInputs(Map.empty).get shouldEqual Map.empty[FullyQualifiedName, WdlValue]
+  }
+}
+

--- a/src/test/scala/wdl4s/SameNameParametersSpec.scala
+++ b/src/test/scala/wdl4s/SameNameParametersSpec.scala
@@ -18,7 +18,7 @@ class SameNameParametersSpec extends FlatSpec with Matchers {
   val task = namespace1.findTask("test").get
 
   "A task with command that uses the same parameter more than once" should "only count it as one input" in {
-    task.inputs shouldEqual Seq(TaskInput(name="x", wdlType=WdlStringType))
+    task.declarations.map(_.toWdlString) shouldEqual Seq("String x")
   }
 
   it should "instantiate the command with duplicated parameter names properly" in {

--- a/src/test/scala/wdl4s/SampleWdl.scala
+++ b/src/test/scala/wdl4s/SampleWdl.scala
@@ -2,6 +2,8 @@ package wdl4s
 
 import java.nio.file.{Files, Path}
 
+import wdl4s.values.WdlValue
+
 import scala.language.postfixOps
 
 // FIXME: Figure out if anything can be removed from cromwell completely or pulled from here
@@ -220,6 +222,37 @@ object SampleWdl {
         |    call E
         |  }
         |  call D {input: D_in = B.B_out}
+        |}
+      """.stripMargin
+
+    override lazy val rawInputs = Map.empty[String, String]
+  }
+
+  class DeclarationsWdl extends SampleWdl {
+    override def wdlSource(runtime: String = "") =
+      """task a {
+        |  String foo = "notfoo"
+        |  String bar = "bar"
+        |  String foobar = foo + bar
+        |  command {ps}
+        |}
+        |
+        |task b {
+        |  Int foo = 10
+        |  Int bar = 2
+        |  Int foobar = foo + bar
+        |  Int foobar2 = foo + 2
+        |  command {ps}
+        |}
+        |
+        |workflow w {
+        |  String foo = "foo"
+        |  String bar = "bar"
+        |  String foobar = foo + bar
+        |
+        |  call a
+        |  call a as a_prime
+        |  call b
         |}
       """.stripMargin
 


### PR DESCRIPTION
This is part of DSDEEPB-2455

`Declaration` previously was not scoped, but we tried to fake it by passing it a FQN string.  However, we were passing the literal string `"name"` as the FQN for all declarations that were coming from tasks.  This is leading Cromwell to storing `name` as scope FQNs in the database.

This patch allows for `Workflow` and `Call` to call `.scopedDeclarations` to get a declaration that's properly scoped, and can provide a real implementation of `.fullyQualifiedName`

Also changed:

* `TaskOutput` is now a `Declaration` that has a required expression
* All declarations on the task level are type checked at compile time
* Removed `inputs` field on `Task`. Using `declarations` field instead.