### PR TITLE
Add a workflow only static declarations evaluation method

### DIFF
--- a/src/main/scala/wdl4s/TaskOutput.scala
+++ b/src/main/scala/wdl4s/TaskOutput.scala
@@ -1,12 +1,9 @@
 package wdl4s
 
-import wdl4s.AstTools.EnhancedAstNode
-import wdl4s.expression.{NoFunctions, WdlStandardLibraryFunctionsType}
-import wdl4s.types.WdlType
-import wdl4s.parser.WdlParser.{Ast, SyntaxError, Terminal}
 import com.typesafe.scalalogging.LazyLogging
-
-import scala.util.{Failure, Success}
+import wdl4s.AstTools.EnhancedAstNode
+import wdl4s.parser.WdlParser.Ast
+import wdl4s.types.WdlType
 
 object TaskOutput extends LazyLogging {
   def apply(ast: Ast, syntaxErrorFormatter: WdlSyntaxErrorFormatter): TaskOutput = {

--- a/src/main/scala/wdl4s/WdlExpression.scala
+++ b/src/main/scala/wdl4s/WdlExpression.scala
@@ -109,7 +109,8 @@ object WdlExpression {
    */
   def standardLookupFunction(parameters: Map[String, WdlValue], declarations: Seq[Declaration], functions: WdlFunctions[WdlValue]): String => WdlValue = {
     def resolveParameter(name: String): Try[WdlValue] = parameters.get(name) match {
-      case Some(value) => Success(value)
+      case Some(value: WdlExpression) => Success(value.evaluate(lookup, functions)).getOrElse(Failure(new WdlExpressionException(s"Could not evaluate parameter: $value")))
+      case Some(value: WdlValue) => Success(value)
       case None => Failure(new WdlExpressionException(s"Could not resolve variable '$name' as an input parameter"))
     }
     def resolveDeclaration(lookup: ScopedLookupFunction)(name: String) = declarations.find(_.name == name) match {

--- a/src/main/scala/wdl4s/WdlNamespace.scala
+++ b/src/main/scala/wdl4s/WdlNamespace.scala
@@ -110,7 +110,7 @@ case class NamespaceWithWorkflow(importedAs: Option[String],
    * For the declarations that have an expression attached to it already, evaluate the expression
    * and return the value for storage in the symbol store
    */
-  def staticDeclarationsRecursive(userInputs: WorkflowCoercedInputs, wdlFunctions: WdlStandardLibraryFunctions): Try[WorkflowCoercedInputs] = {
+  private def evaluateStaticDeclarations(userInputs: WorkflowCoercedInputs, wdlFunctions: WdlStandardLibraryFunctions, scopedDeclarations: Seq[Seq[ScopedDeclaration]]): Try[WorkflowCoercedInputs] = {
     def evalDeclaration(accumulated: Map[String, Try[WdlValue]], current: ScopedDeclaration): Map[String, Try[WdlValue]] = {
       current.expression match {
         case Some(expr) =>
@@ -122,9 +122,16 @@ case class NamespaceWithWorkflow(importedAs: Option[String],
     }
 
     // declarationsByScope is a Seq[Seq[ScopedDeclaration]] where each Declaration in the Seq[ScopedDeclaration] have the same scope
-    val declarationsByScope = workflow.calls.map(_.scopedDeclarations) ++ Seq(workflow.scopedDeclarations)
-    val attemptedEvaluations = declarationsByScope.flatMap(d => d.foldLeft(Map.empty[String, Try[WdlValue]])(evalDeclaration)).toMap
+    val attemptedEvaluations = scopedDeclarations.flatMap(d => d.foldLeft(Map.empty[String, Try[WdlValue]])(evalDeclaration)).toMap
     TryUtil.sequenceMap(attemptedEvaluations)
+  }
+
+  def staticWorkflowDeclarationsRecursive(userInputs: WorkflowCoercedInputs, wdlFunctions: WdlStandardLibraryFunctions): Try[WorkflowCoercedInputs] = {
+    evaluateStaticDeclarations(userInputs, wdlFunctions, Seq(workflow.scopedDeclarations))
+  }
+
+  def staticDeclarationsRecursive(userInputs: WorkflowCoercedInputs, wdlFunctions: WdlStandardLibraryFunctions): Try[WorkflowCoercedInputs] = {
+    evaluateStaticDeclarations(userInputs, wdlFunctions, Seq(workflow.scopedDeclarations) ++ workflow.calls.map(_.scopedDeclarations))
   }
 
   /**

--- a/src/main/scala/wdl4s/expression/WdlEvaluator.scala
+++ b/src/main/scala/wdl4s/expression/WdlEvaluator.scala
@@ -1,0 +1,83 @@
+package wdl4s.expression
+
+import wdl4s.WdlExpression._
+import wdl4s.expression.WdlEvaluator.{ExpressionNotFound, StringMapper, WdlValueMapper}
+import wdl4s.values.WdlValue
+import wdl4s._
+
+import scala.util.{Failure, Success, Try}
+
+object WdlEvaluator {
+  type StringMapper = String => String
+  type WdlValueMapper = WdlValue => WdlValue
+  case class ExpressionNotFound(declaration: Declaration) extends Exception(
+    s"Declaration $declaration does not have an expression and cannot be evaluated."
+  )
+}
+
+// Can evaluate a wdl value
+class WdlEvaluator(defaultLookup: ScopedLookupFunction,
+                engineFunctions: WdlFunctions[WdlValue],
+                preValueMapper: StringMapper,
+                postValueMapper: WdlValueMapper) {
+
+  private def lookup = defaultLookup compose preValueMapper
+
+  // Evaluate a wdl value with the given lookup function, and optionally coerce the result to coerceTo
+  private def evaluateValueWith(customLookup: ScopedLookupFunction, wdlValue: WdlValue) = {
+    wdlValue match {
+      case wdlExpression: WdlExpression => wdlExpression.evaluate(customLookup, engineFunctions) map postValueMapper
+      case v: WdlValue => Success(v)
+    }
+  }
+
+  private def evaluateDeclarationWith(customLookup: ScopedLookupFunction, declaration: Declaration) = {
+    val expression = declaration match {
+      case resolved: ResolvedDeclaration => Success(resolved.unevaluatedValue)
+      case decl if decl.expression.isDefined => Success(declaration.expression.get)
+      case _ => Failure(new ExpressionNotFound(declaration))
+    }
+
+    expression flatMap { expr =>
+      evaluateValueWith(customLookup, expr) flatMap declaration.wdlType.coerceRawValue
+    }
+  }
+
+  private def mapLookup(values: Map[LocallyQualifiedName, Try[WdlValue]], identifier: String): Try[WdlValue] = {
+    values.getOrElse(identifier, Failure(new WdlExpressionException(s"Could not resolve variable '$identifier' as an input parameter")))
+  }
+
+  def evaluateValue(wdlValue: WdlValue): Try[WdlValue] = evaluateValueWith(lookup, wdlValue)
+
+  def evaluateDeclaration(declaration: Declaration): Try[WdlValue] = evaluateDeclarationWith(lookup, declaration)
+
+  def evaluateDeclarations(declarations: Seq[Declaration]): Map[Declaration, Try[WdlValue]] = {
+    declarations.foldLeft(Map.empty[Declaration, Try[WdlValue]])((evaluatedValues, declaration) => {
+
+      def enhancedLookup(identifier: String) = {
+        val mappedDeclaration =  evaluatedValues map { case (k, v) => k.name -> v }
+        mapLookup(mappedDeclaration, identifier) getOrElse lookup(identifier)
+      }
+
+      evaluatedValues + (declaration -> evaluateDeclarationWith(enhancedLookup, declaration))
+    })
+  }
+
+  def evaluateValues(wdlValues: Map[LocallyQualifiedName, WdlValue]): Map[LocallyQualifiedName, Try[WdlValue]] = {
+    wdlValues.foldLeft(Map.empty[LocallyQualifiedName, Try[WdlValue]])((evaluatedValues, pair) => {
+
+      val (name, wdlValue) = pair
+      def enhancedLookup(identifier: String) = mapLookup(evaluatedValues, identifier) getOrElse lookup(identifier)
+
+      evaluatedValues + (name -> evaluateValueWith(enhancedLookup, wdlValue))
+    })
+  }
+}
+
+// Can build an evaluator from engine functions and valueMapper
+class WdlEvaluatorBuilder(builder: (WdlFunctions[WdlValue], StringMapper, WdlValueMapper) => WdlEvaluator) {
+
+  def build(functions: WdlFunctions[WdlValue],
+            preMapper: StringMapper = identity[String],
+            postMapper: WdlValueMapper = identity[WdlValue]) = builder(functions, preMapper, postMapper)
+}

--- a/src/test/scala/wdl4s/DeclarationSpec.scala
+++ b/src/test/scala/wdl4s/DeclarationSpec.scala
@@ -130,6 +130,18 @@ class DeclarationSpec extends FlatSpec with Matchers {
     }
   }
 
+  "A workflow" should "Be able to evaluate static workflow declarations" in {
+    namespace.staticWorkflowDeclarationsRecursive(Map.empty[String, WdlValue], NoFunctions) match {
+      case Failure(ex) => fail("Expected all declarations to be statically evaluatable", ex)
+      case Success(values) =>
+        values shouldEqual Map(
+          "w.foo" -> WdlString("foo"),
+          "w.bar" -> WdlString("bar"),
+          "w.foobar" -> WdlString("foobar")
+        )
+    }
+  }
+
   "A namespace" should "Be able to coerce inputs" in {
     namespace.coerceRawInputs(Map.empty).get shouldEqual Map.empty[FullyQualifiedName, WdlValue]
   }


### PR DESCRIPTION
`staticDeclarationsRecursive` evaluates all statics declarations, including the ones in a task. This won't work with the new evaluation design because we want those to be evaluated by the backend instead. This creates a `staticWorkflowDeclarationsRecursive` that only evaluates workflow declarations.