### PR TITLE
Updated dependencies to the latest versions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,11 @@
 import com.typesafe.sbt.GitPlugin.autoImport._
 import sbt.Keys._
-import sbtassembly.MergeStrategy
-import com.typesafe.sbt.SbtGit.GitCommand
 
 name := "wdl4s"
 
 organization := "org.broadinstitute"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 // Upcoming release, or current if we're on the master branch
 git.baseVersion := "0.5"
@@ -20,53 +18,19 @@ git.gitUncommittedChanges := true
 
 versionWithGit
 
-assemblyJarName in assembly := "wdl4s-" + git.baseVersion.value + ".jar"
-
-logLevel in assembly := Level.Info
-
-val DowngradedSprayV = "1.3.1"
+val sprayJsonV = "1.3.2"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
-  "io.spray" %% "spray-json" % DowngradedSprayV,
-  "org.scalaz" %% "scalaz-core" % "7.1.3",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.4.0",
+  "io.spray" %% "spray-json" % sprayJsonV,
+  "org.scalaz" %% "scalaz-core" % "7.2.5",
   "commons-codec" % "commons-codec" % "1.10",
-  "commons-io" % "commons-io" % "2.4",
+  "commons-io" % "commons-io" % "2.5",
   "org.apache.commons" % "commons-lang3" % "3.4",
-  "com.github.pathikrit" %% "better-files" % "2.13.0",
+  "com.github.pathikrit" %% "better-files" % "2.16.0",
   //---------- Test libraries -------------------//
-  "org.scalatest" %% "scalatest" % "2.2.5" % Test
+  "org.scalatest" %% "scalatest" % "3.0.0" % Test
 )
-
-val customMergeStrategy: String => MergeStrategy = {
-  case x if Assembly.isConfigFile(x) =>
-    MergeStrategy.concat
-  case PathList(ps@_*) if Assembly.isReadme(ps.last) || Assembly.isLicenseFile(ps.last) =>
-    MergeStrategy.rename
-  case PathList("META-INF", path@_*) =>
-    path map {
-      _.toLowerCase
-    } match {
-      case ("manifest.mf" :: Nil) | ("index.list" :: Nil) | ("dependencies" :: Nil) =>
-        MergeStrategy.discard
-      case ps@(x :: xs) if ps.last.endsWith(".sf") || ps.last.endsWith(".dsa") =>
-        MergeStrategy.discard
-      case "plexus" :: xs =>
-        MergeStrategy.discard
-      case "spring.tooling" :: xs =>
-        MergeStrategy.discard
-      case "services" :: xs =>
-        MergeStrategy.filterDistinctLines
-      case ("spring.schemas" :: Nil) | ("spring.handlers" :: Nil) =>
-        MergeStrategy.filterDistinctLines
-      case _ => MergeStrategy.deduplicate
-    }
-  case "asm-license.txt" | "overview.html" | "cobertura.properties" =>
-    MergeStrategy.discard
-  case _ => MergeStrategy.deduplicate
-}
-
-assemblyMergeStrategy in assembly := customMergeStrategy
 
 // The reason why -Xmax-classfile-name is set is because this will fail
 // to build on Docker otherwise.  The reason why it's 200 is because it
@@ -75,3 +39,5 @@ assemblyMergeStrategy in assembly := customMergeStrategy
 // https://github.com/sbt/sbt-assembly/issues/69
 // https://github.com/scala/pickling/issues/10
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xmax-classfile-name", "200")
+
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDSI")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,7 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
-
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")

--- a/src/main/scala/wdl4s/AstTools.scala
+++ b/src/main/scala/wdl4s/AstTools.scala
@@ -144,7 +144,7 @@ object AstTools {
    * @return an Abstract Syntax Tree (WdlParser.Ast) representing the structure of the code
    * @throws WdlParser.SyntaxError if there was a problem parsing the source code
    */
-  def getAst(wdlFile: Path): Ast = getAst(wdlFile.contentAsString, wdlFile.name)
+  def getAst(wdlFile: Path): Ast = getAst(File(wdlFile).contentAsString, File(wdlFile).name)
 
   def findAsts(ast: AstNode, name: String): Seq[Ast] = {
     ast match {

--- a/src/main/scala/wdl4s/ExceptionWithErrors.scala
+++ b/src/main/scala/wdl4s/ExceptionWithErrors.scala
@@ -2,14 +2,14 @@ package wdl4s
 
 import scalaz.NonEmptyList
 
-trait ThrowableWithErrors extends Exception {
+trait ExceptionWithErrors extends Exception {
   def message: String
   def errors: NonEmptyList[String]
 
   override def getMessage = {
-    s"""$message\n${errors.list.mkString("\n")}"""
+    s"""$message\n${errors.list.toList.mkString("\n")}"""
   }
 }
 
 class UnsatisfiedInputsException(message: String) extends Exception(message)
-class ValidationException(val message: String, val errors: NonEmptyList[String]) extends ThrowableWithErrors
+class ValidationException(val message: String, val errors: NonEmptyList[String]) extends ExceptionWithErrors

--- a/src/main/scala/wdl4s/WdlNamespace.scala
+++ b/src/main/scala/wdl4s/WdlNamespace.scala
@@ -293,7 +293,7 @@ object WdlNamespace {
 
   private def localImportResolver(path: String): WdlSource = readFile(Paths.get(path))
 
-  private def readFile(wdlFile: Path): WdlSource = wdlFile.contentAsString
+  private def readFile(wdlFile: Path): WdlSource = File(wdlFile).contentAsString
 }
 
 object NamespaceWithWorkflow {

--- a/src/test/scala/wdl4s/ExceptionWithErrorsSpec.scala
+++ b/src/test/scala/wdl4s/ExceptionWithErrorsSpec.scala
@@ -4,10 +4,10 @@ import org.scalatest.{Matchers, FlatSpec}
 
 import scalaz.NonEmptyList
 
-class WdlExceptionsSpec extends FlatSpec with Matchers {
+class ExceptionWithErrorsSpec extends FlatSpec with Matchers {
 
-  "ThrowableWithErrors Exceptions" should "aggregate errors in getMessage method" in {
-    val exception = new RuntimeException with ThrowableWithErrors {
+  "ExceptionWithErrors" should "aggregate errors in getMessage method" in {
+    val exception = new RuntimeException with ExceptionWithErrors {
       val message = "This is absolutely NOT working."
       val errors = NonEmptyList("because of A", "and also B", "and maybe C")
     }

--- a/src/test/scala/wdl4s/TestFileUtil.scala
+++ b/src/test/scala/wdl4s/TestFileUtil.scala
@@ -11,10 +11,10 @@ trait TestFileUtil {
       case Some(path) => Files.createTempFile(path, prefix, suffix)
       case None => Files.createTempFile(prefix, suffix)
     }
-    file.write(contents).path
+    File(file).write(contents).path
   }
 
   def createFile(name: String, dir: Path, contents: String) = {
-    dir.createDirectories()./(name).write(contents).path
+    File(dir).createDirectories()./(name).write(contents).path
   }
 }


### PR DESCRIPTION
Printing test times, minimal stack traces, and resummarizing tests failures, via http://www.scalatest.org/user_guide/running_your_tests.
Renamed `ThrowableWithErrors` to `ExceptionWithErrors`.