### PR TITLE
Declaration evaluation

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -54,8 +54,8 @@ I introduced the concept of a `GraphNode` trait:
 
 ```scala
 trait GraphNode {
-  def upstream: Set[Scope with GraphNode]
-  def downstream: Set[Scope with GraphNode]
+  def upstream: Set[GraphNode]
+  def downstream: Set[GraphNode]
 }
 ```
 
@@ -95,7 +95,7 @@ workflow w {
 If you'd like `b.upstream` to return `call a as a0`, `call a as a1`, AND `Array[Int] ints = [a0.o, a1.o]`, this can be done easily like this:
 
 ```scala
-def upstreamRecursive(node: GraphNode): Set[Scope with GraphNode] = {
+def upstreamRecursive(node: GraphNode): Set[GraphNode] = {
   node.upstream ++ node.upstream.flatMap(upstreamRecursive)
 }
 ```
@@ -121,7 +121,7 @@ trait Scope {
   def ancestry: Seq[Scope]
   def descendants: Set[Scope]
   def closestCommonAncestor(other: Scope): Option[Scope]
-  def resolveVariable(name: String): Option[Scope with GraphNode]
+  def resolveVariable(name: String): Option[GraphNode]
   def lookupFunction(inputs: WorkflowCoercedInputs,
                      wdlFunctions: WdlFunctions[WdlValue],
                      shards: Map[Scatter, Int] = Map.empty[Scatter, Int],

--- a/src/main/scala/wdl4s/Call.scala
+++ b/src/main/scala/wdl4s/Call.scala
@@ -60,7 +60,7 @@ object Call {
 sealed abstract class Call(val alias: Option[String],
                     val callable: Callable,
                     val inputMappings: Map[String, WdlExpression],
-                    val ast: Ast) extends Scope with GraphNode with WorkflowScoped {
+                    val ast: Ast) extends GraphNode with WorkflowScoped {
   val unqualifiedName: String = alias getOrElse callable.unqualifiedName
   
   def callType: String
@@ -75,7 +75,7 @@ sealed abstract class Call(val alias: Option[String],
   
   override def children: Seq[Scope] = super.children ++ outputs
   
-  lazy val upstream: Set[Scope with GraphNode] = {
+  lazy val upstream: Set[GraphNode] = {
     val dependentNodes = for {
       expr <- inputMappings.values
       variable <- expr.variableReferences
@@ -90,7 +90,7 @@ sealed abstract class Call(val alias: Option[String],
     (dependentNodes ++ firstScatterOrIf.toSeq).toSet
   }
 
-  lazy val downstream: Set[Scope with GraphNode] = {
+  lazy val downstream: Set[GraphNode] = {
     def expressions(node: GraphNode): Iterable[WdlExpression] = node match {
       case scatter: Scatter => Set(scatter.collection)
       case call: TaskCall => call.inputMappings.values

--- a/src/main/scala/wdl4s/GraphNode.scala
+++ b/src/main/scala/wdl4s/GraphNode.scala
@@ -1,6 +1,6 @@
 package wdl4s
 
-trait GraphNode {
-  def upstream: Set[Scope with GraphNode]
-  def downstream: Set[Scope with GraphNode]
+trait GraphNode extends Scope {
+  def upstream: Set[GraphNode]
+  def downstream: Set[GraphNode]
 }

--- a/src/main/scala/wdl4s/If.scala
+++ b/src/main/scala/wdl4s/If.scala
@@ -21,11 +21,11 @@ object If {
   * @param condition WDL Expression representing the condition in which to execute this If-block
   */
 case class If(index: Int, condition: WdlExpression, ast: Ast)
-  extends Scope with GraphNode with WorkflowScoped {
+  extends GraphNode with WorkflowScoped {
   val unqualifiedName = s"${If.FQNIdentifier}_$index"
   override def appearsInFqn = false
 
-  lazy val upstream: Set[Scope with GraphNode] = {
+  lazy val upstream: Set[GraphNode] = {
     val referencedNodes = for {
       variable <- condition.variableReferences
       node <- resolveVariable(variable.sourceString)
@@ -40,7 +40,7 @@ case class If(index: Int, condition: WdlExpression, ast: Ast)
     (referencedNodes ++ firstScatterOrIf.toSeq).toSet
   }
 
-  lazy val downstream: Set[Scope with GraphNode] = {
+  lazy val downstream: Set[GraphNode] = {
     for {
       node <- namespace.descendants.collect({ 
         case n: GraphNode if n.fullyQualifiedName != fullyQualifiedName => n 
@@ -49,6 +49,6 @@ case class If(index: Int, condition: WdlExpression, ast: Ast)
     } yield node
   }
 
-  override def toString(): String = s"[If fqn=$fullyQualifiedName, condition=${condition.toWdlString}]"
+  override def toString: String = s"[If fqn=$fullyQualifiedName, condition=${condition.toWdlString}]"
 }
 

--- a/src/main/scala/wdl4s/Scatter.scala
+++ b/src/main/scala/wdl4s/Scatter.scala
@@ -21,12 +21,11 @@ object Scatter {
  * @param item Item which this block is scattering over
  * @param collection Wdl Expression corresponding to the collection this scatter is looping through
  */
-case class Scatter(index: Int, item: String, collection: WdlExpression, ast: Ast)
-  extends Scope with GraphNode with WorkflowScoped {
+case class Scatter(index: Int, item: String, collection: WdlExpression, ast: Ast) extends GraphNode with WorkflowScoped {
   val unqualifiedName = s"${Scatter.FQNIdentifier}_$index"
   override def appearsInFqn = false
 
-  lazy val upstream: Set[Scope with GraphNode] = {
+  lazy val upstream: Set[GraphNode] = {
     val referencedNodes = for {
       variable <- collection.variableReferences
       node <- resolveVariable(variable.sourceString)
@@ -41,7 +40,7 @@ case class Scatter(index: Int, item: String, collection: WdlExpression, ast: Ast
     (referencedNodes ++ firstScatterOrIf.toSeq).toSet
   }
 
-  lazy val downstream: Set[Scope with GraphNode] = {
+  lazy val downstream: Set[GraphNode] = {
     for {
       node <- namespace.descendants.collect({ 
         case n: GraphNode if n.fullyQualifiedName != fullyQualifiedName => n 
@@ -50,5 +49,5 @@ case class Scatter(index: Int, item: String, collection: WdlExpression, ast: Ast
     } yield node
   }
 
-  override def toString(): String = s"[Scatter fqn=$fullyQualifiedName, item=$item, collection=${collection.toWdlString}]"
+  override def toString: String = s"[Scatter fqn=$fullyQualifiedName, item=$item, collection=${collection.toWdlString}]"
 }

--- a/src/main/scala/wdl4s/WdlNamespace.scala
+++ b/src/main/scala/wdl4s/WdlNamespace.scala
@@ -9,7 +9,7 @@ import wdl4s.command.ParameterCommandPart
 import wdl4s.expression.{NoFunctions, WdlStandardLibraryFunctions, WdlStandardLibraryFunctionsType}
 import wdl4s.parser.WdlParser._
 import wdl4s.types._
-import wdl4s.util.TryUtil
+import wdl4s.util.{AggregatedException, TryUtil}
 import wdl4s.values._
 
 import scala.collection.JavaConverters._
@@ -134,10 +134,13 @@ case class WdlNamespaceWithWorkflow(importedAs: Option[String],
       (declarations ++ workflowDeclarations).foldLeft(Map.empty[FullyQualifiedName, Try[WdlValue]])(evalDeclaration)
     }
 
-    val evaluated = evalScope
-    // Filter out declarations which evaluation failed because a call output variable could not be resolved, as this method is meant for pre-execution validation
-    val filtered = evaluated filterNot {
-      case (_, Failure(_: OutputVariableLookupException)) => true
+    val filteredExceptions: Set[Class[_ <: Throwable]] = Set(classOf[OutputVariableLookupException], classOf[ScatterIndexNotFound])
+    
+    // Filter out declarations for which evaluation failed because a call output variable could not be resolved, or a shard could not be found,
+    // as this method is meant for pre-execution validation
+    val filtered = evalScope filterNot {
+      case (_, Failure(ex)) if filteredExceptions.contains(ex.getClass) => true
+      case (_, Failure(e: AggregatedException)) => e.exceptions forall { ex => filteredExceptions.contains(ex.getClass) }
       case _ => false
     }
     
@@ -422,9 +425,9 @@ object WdlNamespace {
 
   def lookupType(from: Scope)(n: String): WdlType = {
     from.resolveVariable(n) match {
-      case Some(d: DeclarationInterface) => d.wdlType
+      case Some(d: DeclarationInterface) => d.relativeWdlType(from)
       case Some(c: Call) => WdlCallOutputsObjectType(c)
-      case Some(s: Scatter) => s.collection.evaluateType(lookupType(s), new WdlStandardLibraryFunctionsType) match {
+      case Some(s: Scatter) => s.collection.evaluateType(lookupType(s), new WdlStandardLibraryFunctionsType, Option(from)) match {
         case Success(a: WdlArrayType) => a.memberType
         case _ => throw VariableLookupException(s"Variable $n references a scatter block ${s.fullyQualifiedName}, but the collection does not evaluate to an array")
       }
@@ -435,7 +438,7 @@ object WdlNamespace {
   
   def typeCheckDeclaration(decl: DeclarationInterface, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Option[SyntaxError] = {
     decl.expression flatMap { expr =>
-      expr.evaluateType(lookupType(decl), new WdlStandardLibraryFunctionsType) match {
+      expr.evaluateType(lookupType(decl), new WdlStandardLibraryFunctionsType, Option(decl)) match {
         case Success(wdlType) if !decl.wdlType.isCoerceableFrom(wdlType) =>
           Option(new SyntaxError(wdlSyntaxErrorFormatter.taskOutputExpressionTypeDoesNotMatchDeclaredType(
             declarationName(decl.ast), decl.wdlType, wdlType

--- a/src/main/scala/wdl4s/WdlNamespace.scala
+++ b/src/main/scala/wdl4s/WdlNamespace.scala
@@ -134,7 +134,14 @@ case class WdlNamespaceWithWorkflow(importedAs: Option[String],
       (declarations ++ workflowDeclarations).foldLeft(Map.empty[FullyQualifiedName, Try[WdlValue]])(evalDeclaration)
     }
 
-    TryUtil.sequenceMap(evalScope)
+    val evaluated = evalScope
+    // Filter out declarations which evaluation failed because a call output variable could not be resolved, as this method is meant for pre-execution validation
+    val filtered = evaluated filterNot {
+      case (_, Failure(_: OutputVariableLookupException)) => true
+      case _ => false
+    }
+    
+    TryUtil.sequenceMap(filtered)
   }
 }
 

--- a/src/main/scala/wdl4s/WorkflowScoped.scala
+++ b/src/main/scala/wdl4s/WorkflowScoped.scala
@@ -1,7 +1,7 @@
 package wdl4s
 
 trait WorkflowScoped extends Scope {
-  def workflow: Workflow = ancestry.collectFirst({ case w: Workflow => w }).getOrElse(
+  def parentWorkflow: Workflow = ancestry.collectFirst({ case w: Workflow => w }).getOrElse(
     throw new IllegalStateException(s"Grammar constraint violation: $fullyQualifiedName should be contained in a workflow")
   )
 }

--- a/src/main/scala/wdl4s/package.scala
+++ b/src/main/scala/wdl4s/package.scala
@@ -12,7 +12,9 @@ package object wdl4s {
   type EvaluatedTaskInputs = Map[Declaration, WdlValue]
   type ImportResolver = String => WdlSource
   type OutputResolver = (Call, Option[Int]) => Try[WdlCallOutputsObject]
-  val NoOutputResolver: OutputResolver = (c: Call, i: Option[Int]) => Failure(new VariableLookupException(s"Could not find outputs for call ${c.fullyQualifiedName} at index $i"))
+  
+  class OutputVariableLookupException(call: Call, index: Option[Int]) extends VariableLookupException(s"Could not find outputs for call ${call.fullyQualifiedName} at index $index")
+  val NoOutputResolver: OutputResolver = (c: Call, i: Option[Int]) => Failure(new OutputVariableLookupException(c, i))
 
   trait TsvSerializable {
     def tsvSerialize: Try[String]

--- a/src/main/scala/wdl4s/package.scala
+++ b/src/main/scala/wdl4s/package.scala
@@ -1,4 +1,4 @@
-import wdl4s.values.{WdlCallOutputsObject, WdlValue}
+import wdl4s.values.WdlValue
 
 import scala.util.{Failure, Try}
 
@@ -11,10 +11,10 @@ package object wdl4s {
   type LocallyQualifiedName = String
   type EvaluatedTaskInputs = Map[Declaration, WdlValue]
   type ImportResolver = String => WdlSource
-  type OutputResolver = (Call, Option[Int]) => Try[WdlCallOutputsObject]
+  type OutputResolver = (GraphNode, Option[Int]) => Try[WdlValue]
   
-  class OutputVariableLookupException(call: Call, index: Option[Int]) extends VariableLookupException(s"Could not find outputs for call ${call.fullyQualifiedName} at index $index")
-  val NoOutputResolver: OutputResolver = (c: Call, i: Option[Int]) => Failure(new OutputVariableLookupException(c, i))
+  class OutputVariableLookupException(node: GraphNode, index: Option[Int]) extends VariableLookupException(s"Could not find outputs for call ${node.fullyQualifiedName} at index $index")
+  val NoOutputResolver: OutputResolver = (node: GraphNode, i: Option[Int]) => Failure(new OutputVariableLookupException(node, i))
 
   trait TsvSerializable {
     def tsvSerialize: Try[String]

--- a/src/test/scala/wdl4s/CallSpec.scala
+++ b/src/test/scala/wdl4s/CallSpec.scala
@@ -17,7 +17,7 @@ class CallSpec extends WordSpec with Matchers {
 
     val inputs = namespace.coerceRawInputs(SampleWdl.TaskDeclarationsWdl.rawInputs).get
     
-    def outputResolver(call: Call, index: Option[Int]): Try[WdlCallOutputsObject] = {
+    def outputResolver(call: GraphNode, index: Option[Int]): Try[WdlValue] = {
       (call, index) match {
         case (c, Some(2)) if c == callT => Success(WdlCallOutputsObject(callT, Map("o" -> WdlString(s"c ${index.getOrElse(-1)}"))))
         case (c, None) if c == callT2 => Success(WdlCallOutputsObject(callT2, Map(

--- a/src/test/scala/wdl4s/WdlWiringSpec.scala
+++ b/src/test/scala/wdl4s/WdlWiringSpec.scala
@@ -172,16 +172,16 @@ class WdlWiringSpec extends FlatSpec with Matchers {
     expectedAncestryFile.contentAsString.parseJson.asInstanceOf[JsObject].fields.asInstanceOf[Map[String, JsArray]] map {
       case (k, v) =>
         val expectedAncestry = v.elements.asInstanceOf[Vector[JsString]].map(n => namespace.resolve(n.value).get)
-        val resolvedFqn = namespace.resolve(k).get.asInstanceOf[Scope with GraphNode]
+        val resolvedFqn = namespace.resolve(k).get
         resolvedFqn -> expectedAncestry
     }
   }
 
-  private def expectedUpstream(testDir: File, namespace: WdlNamespaceWithWorkflow): Map[Scope with GraphNode, Set[Scope]] = {
+  private def expectedUpstream(testDir: File, namespace: WdlNamespaceWithWorkflow): Map[GraphNode, Set[Scope]] = {
     val expectedUpstreamFile = testDir / "upstream.expectations"
 
     if (!expectedUpstreamFile.exists) {
-      val upstreamFqns = namespace.descendants.collect({ case n: Scope with GraphNode => n }) map { node =>
+      val upstreamFqns = namespace.descendants.collect({ case n: GraphNode => n }) map { node =>
         node.fullyQualifiedName -> JsArray(node.upstream.toVector.map(_.fullyQualifiedName).sorted.map(JsString(_)))
       }
       val jsObject = JsObject(ListMap(upstreamFqns.toSeq.sortBy(_._1): _*))
@@ -191,16 +191,16 @@ class WdlWiringSpec extends FlatSpec with Matchers {
     expectedUpstreamFile.contentAsString.parseJson.asInstanceOf[JsObject].fields.asInstanceOf[Map[String, JsArray]] map {
       case (k, v) =>
         val expectedUpstream = v.elements.asInstanceOf[Vector[JsString]].map(n => namespace.resolve(n.value).get).toSet
-        val resolvedFqn = namespace.resolve(k).get.asInstanceOf[Scope with GraphNode]
+        val resolvedFqn = namespace.resolve(k).get.asInstanceOf[GraphNode]
         resolvedFqn -> expectedUpstream
     }
   }
 
-  private def expectedDownstream(testDir: File, namespace: WdlNamespaceWithWorkflow): Map[Scope with GraphNode, Set[Scope]] = {
+  private def expectedDownstream(testDir: File, namespace: WdlNamespaceWithWorkflow): Map[GraphNode, Set[Scope]] = {
     val expectedDownstreamFile = testDir / "downstream.expectations"
 
     if (!expectedDownstreamFile.exists) {
-      val downstreamFqns = namespace.descendants.collect({ case n: Scope with GraphNode => n }) map { node =>
+      val downstreamFqns = namespace.descendants.collect({ case n: GraphNode => n }) map { node =>
         node.fullyQualifiedName -> JsArray(node.downstream.toVector.map(_.fullyQualifiedName).sorted.map(JsString(_)))
       }
       val jsObject = JsObject(ListMap(downstreamFqns.toSeq.sortBy(_._1): _*))
@@ -209,7 +209,7 @@ class WdlWiringSpec extends FlatSpec with Matchers {
 
     expectedDownstreamFile.contentAsString.parseJson.asInstanceOf[JsObject].fields.asInstanceOf[Map[String, JsArray]] map { case (k, v) =>
       val expectedDownstream = v.elements.asInstanceOf[Vector[JsString]].map(n => namespace.resolve(n.value).get).toSet
-      val resolvedFqn = namespace.resolve(k).get.asInstanceOf[Scope with GraphNode]
+      val resolvedFqn = namespace.resolve(k).get.asInstanceOf[GraphNode]
       resolvedFqn -> expectedDownstream
     }
   }

--- a/src/test/scala/wdl4s/WorkflowSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowSpec.scala
@@ -70,46 +70,47 @@ class WorkflowSpec extends WordSpec with Matchers {
 
     val workflowInputs = Map("main_workflow.workflow_input" -> WdlString("workflow_input"))
 
-    def outputResolverForWorkflow(workflow: Workflow)(call: Call, index: Option[Int])= {
+    def outputResolverForWorkflow(workflow: Workflow)(call: GraphNode, index: Option[Int])= {
       call match {
         // Main Task
-        case c if c == workflow.findCallByName("main_task").get =>
+        case c: Call if c == workflow.findCallByName("main_task").get =>
           Success(WdlCallOutputsObject(c, Map(
             "task_o1" -> WdlString("MainTaskOutputString"),
             "task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8)))
           )))
-        case c if c == workflow.findCallByName("main_task2").get =>
+        case c: Call if c == workflow.findCallByName("main_task2").get =>
           Success(WdlCallOutputsObject(c, Map(
             "task_o1" -> WdlString("MainTask2OutputString"),
             "task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16)))
           )))
-        case c if c == workflow.findCallByName("main_task_in_scatter").get =>
+        case c: Call if c == workflow.findCallByName("main_task_in_scatter").get =>
           Success(WdlCallOutputsObject(c, Map(
             "task_o1" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString")))
           )))
 
         //Sub Task
-        case c if c == workflow.findCallByName("sub_task").get =>
+        case c: Call if c == workflow.findCallByName("sub_task").get =>
           Success(WdlCallOutputsObject(c, Map(
             "sub_task_o1" -> WdlString("SubTaskOutputString")
           )))
-        case c if c == workflow.findCallByName("sub_task2").get =>
+        case c: Call if c == workflow.findCallByName("sub_task2").get =>
           Success(WdlCallOutputsObject(c, Map(
             "sub_task_o1" -> WdlString("SubTask2OutputString")
           )))
 
         // Workflow Task
-        case c if c == workflow.findCallByName("sub_workflow").get =>
+        case c: Call if c == workflow.findCallByName("sub_workflow").get =>
           Success(WdlCallOutputsObject(c, Map(
             "sub_sub_workflow_sub_task_sub_task_o1" -> WdlString("SubWorkflowSubTaskOutputString"),
             "sub_o1" -> WdlString("SubWorkflowOutputString")
           )))
-        case c if c == workflow.findCallByName("sub_workflow2").get =>
+        case c: Call if c == workflow.findCallByName("sub_workflow2").get =>
           Success(WdlCallOutputsObject(c, Map(
             "sub_sub_workflow_sub_task_sub_task_o1" -> WdlString("SubWorkflow2SubTaskOutputString"),
             "sub_o1" -> WdlString("SubWorkflow2OutputString")
           )))
-        case c => fail(s"No output found for call ${c.unqualifiedName}")
+        case c: Call => fail(s"No output found for call ${c.unqualifiedName}")
+        case _ => Failure(new Exception())
       }
     }
 
@@ -454,9 +455,9 @@ class WorkflowSpec extends WordSpec with Matchers {
 
       val ns = WdlNamespaceWithWorkflow.load(wdl)
 
-      def outputResolver(call: Call, index: Option[Int])= {
+      def outputResolver(call: GraphNode, index: Option[Int])= {
         call match {
-          case c if c == ns.workflow.findCallByName("t").get =>
+          case c: Call if c == ns.workflow.findCallByName("t").get =>
             Success(WdlCallOutputsObject(c, Map(
               "o1" -> WdlString("o1"),
               "o2" -> WdlString("o2")


### PR DESCRIPTION
In order to allow for workflow declarations referencing call outputs, the WDL validation needs to be a little bit more flexible and not fail right away if it can't evaluate a workflow declaration at submission time.
- The first commit modifies `staticDeclarationsRecursive` so it doesn't reject the namespace if it can't evaluate a declaration because it couldn't find a call output.
- The second commit makes sure the underlying exception is bubbled up from the lookup function and not a wrapped one.
- The third commit is just a rename for clarity and has nothing to do with the rest.