### PR TITLE
Workflow outputs fix

### DIFF
--- a/src/main/scala/wdl4s/WdlNamespace.scala
+++ b/src/main/scala/wdl4s/WdlNamespace.scala
@@ -173,8 +173,8 @@ object WdlNamespace {
     load(wdlSource, resource.getOrElse("string"), importResolver.getOrElse(Seq(fileResolver)), None)
   }
 
-  private def load(wdlSource: WdlSource, resource: String, importResolver: Seq[ImportResolver], importedAs: Option[String]): WdlNamespace = {
-    WdlNamespace(AstTools.getAst(wdlSource, resource), wdlSource, importResolver, importedAs, root = true)
+  private def load(wdlSource: WdlSource, resource: String, importResolver: Seq[ImportResolver], importedAs: Option[String], root: Boolean = true): WdlNamespace = {
+    WdlNamespace(AstTools.getAst(wdlSource, resource), wdlSource, importResolver, importedAs, root = root)
   }
 
 
@@ -206,7 +206,7 @@ object WdlNamespace {
     val namespaces: Seq[WdlNamespace] = for {
       imp <- imports
       source = tryResolve(imp.uri, importResolvers, List.empty)
-    } yield WdlNamespace.load(source, imp.uri, importResolvers, Option(imp.namespaceName))
+    } yield WdlNamespace.load(source, imp.uri, importResolvers, Option(imp.namespaceName), root = false)
 
     /**
       * Map of Terminal -> WDL Source Code so the syntax error formatter can show line numbers
@@ -341,13 +341,22 @@ object WdlNamespace {
     val callInputSectionErrors = namespace.descendants.collect({ case c: TaskCall => c }).flatMap(
       validateCallInputSection(_, wdlSyntaxErrorFormatter)
     )
+    
+    val workflowOutputErrors = workflows flatMap { _.workflowCalls map { _.calledWorkflow } } collect {
+      case workflow if workflow.workflowOutputWildcards.nonEmpty => 
+        new SyntaxError(
+          s"""Workflow ${workflow.unqualifiedName} is used as a sub workflow but has outputs declared with a deprecated syntax not compatible with sub workflows.
+             |To use this workflow as a sub workflow please update the workflow outputs section to the latest WDL specification.
+             |See https://github.com/broadinstitute/wdl/blob/develop/SPEC.md#outputs""".stripMargin
+        )
+    }
 
     val declarationErrors = for {
       descendant <- namespace.descendants
       declaration <- getDecls(descendant)
       error <- validateDeclaration(declaration, wdlSyntaxErrorFormatter)
     } yield error
-
+    
     def scopeNameAndTerminal(scope: Scope): (String, Terminal) = {
       scope match {
         case ns: WdlNamespace => ("Namespace", imports.find(_.uri == ns.resource).get.namespaceTerminal)
@@ -389,7 +398,7 @@ object WdlNamespace {
       if !task.declarations.map(_.unqualifiedName).contains(variable.getSourceString)
     } yield new SyntaxError(wdlSyntaxErrorFormatter.commandExpressionContainsInvalidVariableReference(task.ast.getAttribute("name").asInstanceOf[Terminal], variable))
 
-    val all = declarationErrors ++ callInputSectionErrors ++ taskCommandReferenceErrors ++ duplicateSiblingScopeNameErrors
+    val all = workflowOutputErrors ++ declarationErrors ++ callInputSectionErrors ++ taskCommandReferenceErrors ++ duplicateSiblingScopeNameErrors
 
     all.toSeq.sortWith({ case (l, r) => l.getMessage < r.getMessage }) match {
       case s: Seq[SyntaxError] if s.nonEmpty => throw s.head

--- a/src/main/scala/wdl4s/WdlNamespace.scala
+++ b/src/main/scala/wdl4s/WdlNamespace.scala
@@ -343,9 +343,9 @@ object WdlNamespace {
     )
     
     val workflowOutputErrors = workflows flatMap { _.workflowCalls map { _.calledWorkflow } } collect {
-      case workflow if workflow.workflowOutputWildcards.nonEmpty => 
+      case calledWorkflow if calledWorkflow.workflowOutputWildcards.nonEmpty => 
         new SyntaxError(
-          s"""Workflow ${workflow.unqualifiedName} is used as a sub workflow but has outputs declared with a deprecated syntax not compatible with sub workflows.
+          s"""Workflow ${calledWorkflow.unqualifiedName} is used as a sub workflow but has outputs declared with a deprecated syntax not compatible with sub workflows.
              |To use this workflow as a sub workflow please update the workflow outputs section to the latest WDL specification.
              |See https://github.com/broadinstitute/wdl/blob/develop/SPEC.md#outputs""".stripMargin
         )

--- a/src/main/scala/wdl4s/Workflow.scala
+++ b/src/main/scala/wdl4s/Workflow.scala
@@ -126,14 +126,12 @@ case class Workflow(unqualifiedName: String,
    */
   lazy val expandedWildcardOutputs: Seq[WorkflowOutput] = {
 
-    def sanitizeFqn(fqn: FullyQualifiedName) = fqn.replaceAll("\\.", "_")
-    
     def toWorkflowOutput(output: DeclarationInterface, wdlType: WdlType) = {
       val locallyQualifiedName = output.parent map { parent => output.locallyQualifiedName(parent) } getOrElse { 
         throw new RuntimeException(s"output ${output.fullyQualifiedName} has no parent Scope") 
       }
       
-      new WorkflowOutput(sanitizeFqn(output.fullyQualifiedName), wdlType, WdlExpression.fromString(locallyQualifiedName), output.ast, Option(this))
+      new WorkflowOutput(output.fullyQualifiedName, wdlType, WdlExpression.fromString(locallyQualifiedName), output.ast, Option(this))
     }
 
     def toWorkflowOutputs(scope: Scope) = {

--- a/src/main/scala/wdl4s/Workflow.scala
+++ b/src/main/scala/wdl4s/Workflow.scala
@@ -117,6 +117,8 @@ case class Workflow(unqualifiedName: String,
     else outputs
     leftOutputs.find(_.unqualifiedName == name)
   }
+  
+  lazy val hasEmptyOutputSection = workflowOutputWildcards.isEmpty && children.collect({ case o: WorkflowOutput => o }).isEmpty
 
   /**
    * All outputs for this workflow and their associated types
@@ -131,7 +133,7 @@ case class Workflow(unqualifiedName: String,
         throw new RuntimeException(s"output ${output.fullyQualifiedName} has no parent Scope") 
       }
       
-      new WorkflowOutput(output.fullyQualifiedName, wdlType, WdlExpression.fromString(locallyQualifiedName), output.ast, Option(this))
+      new WorkflowOutput(output.locallyQualifiedName(this), wdlType, WdlExpression.fromString(locallyQualifiedName), output.ast, Option(this))
     }
 
     def toWorkflowOutputs(scope: Scope) = {
@@ -148,7 +150,7 @@ case class Workflow(unqualifiedName: String,
     }
     
     // No outputs means all outputs
-    val effectiveOutputWildcards = if (workflowOutputWildcards.isEmpty && children.collect({ case o: WorkflowOutput => o }).isEmpty) {
+    val effectiveOutputWildcards = if (hasEmptyOutputSection) {
       calls map { call => WorkflowOutputWildcard(unqualifiedName + "." + call.unqualifiedName, wildcard = true, call.ast) } toSeq
     } else workflowOutputWildcards
 

--- a/src/main/scala/wdl4s/expression/ValueEvaluator.scala
+++ b/src/main/scala/wdl4s/expression/ValueEvaluator.scala
@@ -5,7 +5,7 @@ import wdl4s.AstTools.EnhancedAstNode
 import wdl4s.WdlExpression._
 import wdl4s.types._
 import wdl4s.values.{WdlValue, _}
-import wdl4s.{WdlExpression, WdlExpressionException, WdlNamespace}
+import wdl4s._
 import wdl4s.parser.WdlParser.{Ast, AstNode, Terminal}
 
 import scala.util.{Failure, Success, Try}
@@ -113,7 +113,30 @@ case class ValueEvaluator(override val lookup: String => WdlValue, override val 
               case o: WdlObjectLike =>
                 o.value.get(rhs.getSourceString) match {
                   case Some(v:WdlValue) => Success(v)
-                  case None => Failure(new WdlExpressionException(s"Could not find key ${rhs.getSourceString}"))
+                  case None =>
+                    o match {
+                        // o is a CallOutputsObject which means we failed to find an output value for rhs
+                        // Give a specific error message based on the type of Callable
+                      case callOutputObject: WdlCallOutputsObject => 
+                        callOutputObject.call match {
+                          case workflowCall: WorkflowCall => 
+                            Failure(new WdlExpressionException(
+                              s"""${rhs.getSourceString} is not declared as an output of the sub workflow ${workflowCall.calledWorkflow.fullyQualifiedName}.
+                                 |If you want to use workflow ${workflowCall.calledWorkflow.fullyQualifiedName} as a sub workflow, make sure that its output section is up to date with the latest syntax.
+                                 |See the WDL specification for how to write outputs: https://github.com/broadinstitute/wdl/blob/develop/SPEC.md#outputs""".stripMargin
+                            ))
+                          case taskCall: TaskCall => 
+                            Failure(new WdlExpressionException(
+                              s"""${rhs.getSourceString} is not declared as an output of the task ${taskCall.task.fullyQualifiedName}.
+                                 |Make sure to declare it as an output to be able to use it in the workflow.""".stripMargin
+                            ))
+                          case unkownCall => 
+                            Failure(new WdlExpressionException(
+                              s"Could not find key ${rhs.getSourceString} in Call ${unkownCall.fullyQualifiedName} of unknown type."
+                            ))
+                        }
+                      case _ => Failure(new WdlExpressionException(s"Could not find key ${rhs.getSourceString} in WdlObject"))
+                    }
                 }
               case array: WdlArray if array.wdlType == WdlArrayType(WdlObjectType) =>
                 /**

--- a/src/main/scala/wdl4s/expression/ValueEvaluator.scala
+++ b/src/main/scala/wdl4s/expression/ValueEvaluator.scala
@@ -130,9 +130,9 @@ case class ValueEvaluator(override val lookup: String => WdlValue, override val 
                               s"""${rhs.getSourceString} is not declared as an output of the task ${taskCall.task.fullyQualifiedName}.
                                  |Make sure to declare it as an output to be able to use it in the workflow.""".stripMargin
                             ))
-                          case unkownCall => 
+                          case unknownCall => 
                             Failure(new WdlExpressionException(
-                              s"Could not find key ${rhs.getSourceString} in Call ${unkownCall.fullyQualifiedName} of unknown type."
+                              s"Could not find key ${rhs.getSourceString} in Call ${unknownCall.fullyQualifiedName} of unknown type."
                             ))
                         }
                       case _ => Failure(new WdlExpressionException(s"Could not find key ${rhs.getSourceString} in WdlObject"))

--- a/src/test/scala/wdl4s/WorkflowSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowSpec.scala
@@ -168,61 +168,37 @@ class WorkflowSpec extends WordSpec with Matchers {
         "task wildcard",
         "main_task.*",
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow_main_task_task_o1", WdlStringType, "main_task.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow_main_task_task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2")
+          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
+          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2")
         ),
         Map(
-          "main_workflow_main_task_task_o1" -> WdlString("MainTaskOutputString"),
-          "main_workflow_main_task_task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8)))
+          "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
+          "main_workflow.main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8)))
         )
       ),
       WorkflowOutputTestCase(
         "aliased task wildcard",
         "main_task2.*",
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow_main_task2_task_o1", WdlStringType, "main_task2.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow_main_task2_task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")
+          WorkflowOutputExpectation("main_workflow.main_workflow.main_task2.task_o1", WdlStringType, "main_task2.task_o1"),
+          WorkflowOutputExpectation("main_workflow.main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")
         ),
         Map(
-          "main_workflow_main_task2_task_o1" -> WdlString("MainTask2OutputString"),
-          "main_workflow_main_task2_task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16)))
+          "main_workflow.main_task2.task_o1" -> WdlString("MainTask2OutputString"),
+          "main_workflow.main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16)))
         )
       ),
       WorkflowOutputTestCase(
         "sub task wildcard",
         "sub_task.*",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_sub_task_sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
-        Map("main_workflow_sub_task_sub_task_o1" -> WdlString("SubTaskOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
+        Map("main_workflow.sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased sub task wildcard",
         "sub_task2.*",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_sub_task2_sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
-        Map("main_workflow_sub_task2_sub_task_o1" -> WdlString("SubTask2OutputString"))
-      ),
-      WorkflowOutputTestCase(
-        "sub workflow wildcard",
-        "sub_workflow.*",
-        Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow_sub_workflow_sub_sub_workflow_sub_task_sub_task_o1", WdlStringType, "sub_workflow.sub_sub_workflow_sub_task_sub_task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow_sub_workflow_sub_o1", WdlStringType, "sub_workflow.sub_o1")
-        ),
-        Map(
-          "main_workflow_sub_workflow_sub_o1" -> WdlString("SubWorkflowOutputString"),
-          "main_workflow_sub_workflow_sub_sub_workflow_sub_task_sub_task_o1" -> WdlString("SubWorkflowSubTaskOutputString")
-        )
-      ),
-      WorkflowOutputTestCase(
-        "aliased sub workflow wildcard",
-        "sub_workflow2.*",
-        Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow_sub_workflow2_sub_sub_workflow_sub_task_sub_task_o1", WdlStringType, "sub_workflow2.sub_sub_workflow_sub_task_sub_task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow_sub_workflow2_sub_o1", WdlStringType, "sub_workflow2.sub_o1")
-        ),
-        Map(
-          "main_workflow_sub_workflow2_sub_o1" -> WdlString("SubWorkflow2OutputString"),
-          "main_workflow_sub_workflow2_sub_sub_workflow_sub_task_sub_task_o1" -> WdlString("SubWorkflow2SubTaskOutputString")
-        )
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
+        Map("main_workflow.sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
       ),
       
       /*  DIRECT OUTPUT REFERENCES  */
@@ -240,44 +216,44 @@ class WorkflowSpec extends WordSpec with Matchers {
       WorkflowOutputTestCase(
         "task output",
         "main_task.task_o1", 
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_main_task_task_o1", WdlStringType, "main_task.task_o1")),
-        Map("main_workflow_main_task_task_o1" -> WdlString("MainTaskOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1")),
+        Map("main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased task output",
         "main_task2.task_o2",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_main_task2_task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
-        Map("main_workflow_main_task2_task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
+        Map("main_workflow.main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
       ),
       WorkflowOutputTestCase(
         "task output in scatter",
         "main_task_in_scatter.task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_main_task_in_scatter_task_o1", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
-        Map("main_workflow_main_task_in_scatter_task_o1" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.main_task_in_scatter.task_o1", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
+        Map("main_workflow.main_task_in_scatter.task_o1" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
       ),
       WorkflowOutputTestCase(
         "sub task output",
         "sub_task.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_sub_task_sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
-        Map("main_workflow_sub_task_sub_task_o1" -> WdlString("SubTaskOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
+        Map("main_workflow.sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
         ),
       WorkflowOutputTestCase(
         "aliased sub task output",
         "sub_task2.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_sub_task2_sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
-        Map("main_workflow_sub_task2_sub_task_o1" -> WdlString("SubTask2OutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
+        Map("main_workflow.sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
       ),
       WorkflowOutputTestCase(
         "sub workflow output",
         "sub_workflow.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_sub_workflow_sub_o1", WdlStringType, "sub_workflow.sub_o1")),
-        Map("main_workflow_sub_workflow_sub_o1" -> WdlString("SubWorkflowOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_workflow.sub_o1", WdlStringType, "sub_workflow.sub_o1")),
+        Map("main_workflow.sub_workflow.sub_o1" -> WdlString("SubWorkflowOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased sub workflow output",
         "sub_workflow2.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow_sub_workflow2_sub_o1", WdlStringType, "sub_workflow2.sub_o1")),
-        Map("main_workflow_sub_workflow2_sub_o1" -> WdlString("SubWorkflow2OutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_workflow2.sub_o1", WdlStringType, "sub_workflow2.sub_o1")),
+        Map("main_workflow.sub_workflow2.sub_o1" -> WdlString("SubWorkflow2OutputString"))
       ),
 
       /*  DECLARATIVE SYNTAX  */
@@ -408,13 +384,13 @@ class WorkflowSpec extends WordSpec with Matchers {
         """main_task.*
           |String o1 = main_task.task_o1""".stripMargin,
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow_main_task_task_o1", WdlStringType, "main_task.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow_main_task_task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2"),
+          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
+          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2"),
           WorkflowOutputExpectation("main_workflow.o1", WdlStringType, "main_task.task_o1")
         ),
         Map(
-          "main_workflow_main_task_task_o1" -> WdlString("MainTaskOutputString"),
-          "main_workflow_main_task_task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8))),
+          "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
+          "main_workflow.main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8))),
           "o1" -> WdlString("MainTaskOutputString")
         )
       )
@@ -452,13 +428,13 @@ class WorkflowSpec extends WordSpec with Matchers {
         """.stripMargin
 
       val expectedDeclarations = Seq(
-        WorkflowOutputExpectation("w.w_t_o1", WdlStringType, "t.o1"),
-        WorkflowOutputExpectation("w.w_t_o2", WdlStringType, "t.o2")
+        WorkflowOutputExpectation("w.w.t.o1", WdlStringType, "t.o1"),
+        WorkflowOutputExpectation("w.w.t.o2", WdlStringType, "t.o2")
       )
       
       val expectedEvaluatedOutputs = Map(
-        "w_t_o1" -> WdlString("o1"),
-        "w_t_o2" -> WdlString("o2")
+        "w.t.o1" -> WdlString("o1"),
+        "w.t.o2" -> WdlString("o2")
       )
 
       val ns = WdlNamespaceWithWorkflow.load(wdl)


### PR DESCRIPTION
Do not replace . with _ when expanding workflow outputs in old notation to new notation.
Throw an exception when the namespace is built if a workflow is called as a sub workflow and has old syntax.