### PR TITLE
Support for empty array literals

### DIFF
--- a/src/main/scala/wdl4s/types/WdlArrayType.scala
+++ b/src/main/scala/wdl4s/types/WdlArrayType.scala
@@ -40,7 +40,7 @@ sealed trait WdlArrayType extends WdlType {
   }
 
   override def isCoerceableFrom(otherType: WdlType): Boolean = otherType match {
-    case a: WdlArrayType => memberType.isCoerceableFrom(a.memberType)
+    case WdlArrayType(otherMemberType) => otherMemberType == WdlAnyType || otherMemberType.isCoerceableFrom(memberType)
     case _ => false
   }
 

--- a/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
+++ b/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
@@ -1,9 +1,11 @@
 package wdl4s.types
 
-import wdl4s.values.{WdlArray, WdlInteger, WdlOptionalValue, WdlString}
+import wdl4s.values.{WdlArray, WdlInteger, WdlOptionalValue, WdlString, WdlValue}
 import wdl4s.parser.WdlParser.SyntaxError
 import org.scalatest.{FlatSpec, Matchers}
 import spray.json.{JsArray, JsNumber}
+import wdl4s.WdlExpression
+import wdl4s.expression.NoFunctions
 
 import scala.util.{Failure, Success}
 
@@ -108,6 +110,23 @@ class WdlArrayTypeSpec extends FlatSpec with Matchers  {
       fail("Invalid array initialization should have failed")
     } catch {
       case _: UnsupportedOperationException => // expected
+    }
+  }
+
+  List(WdlStringType, WdlArrayType(WdlIntegerType), WdlPairType(WdlIntegerType, WdlPairType(WdlIntegerType, WdlIntegerType)), WdlOptionalType(WdlStringType)) foreach { desiredMemberType =>
+    it should s"be able to construct an empty Array[${desiredMemberType.toWdlString}] value" in {
+      def noLookup(String: String): WdlValue = fail("No identifiers should be looked up in this test")
+
+      val desiredArrayType = WdlArrayType(desiredMemberType)
+      WdlExpression.fromString("[]").evaluate(noLookup, NoFunctions) match {
+        case Success(emptyArray @ WdlArray(actualArrayType @ WdlArrayType(actualMemberType), actualArrayValue)) =>
+          actualMemberType should be(WdlAnyType)
+          actualArrayValue should be(Seq.empty)
+          desiredArrayType.isCoerceableFrom(actualArrayType) should be(true)
+          desiredArrayType.coerceRawValue(emptyArray) should be(Success(WdlArray(desiredArrayType, Seq.empty)))
+        case Failure(f) => fail("Unable to create an empty array.", f)
+      }
+
     }
   }
 }


### PR DESCRIPTION
Eg:
```
workflow foo {
  Array[String] strings = [ ] # Empty array!
}
```
```
task foo {
  Array[String]? optional
  Array[String] optionalOrDefault = select_first([ optional, [ ] ])
}
```

Because nobody likes the alternative hacky workarounds...