### PR TITLE
fix expanded workflow output unqualified name

### DIFF
--- a/src/main/scala/wdl4s/Workflow.scala
+++ b/src/main/scala/wdl4s/Workflow.scala
@@ -133,7 +133,7 @@ case class Workflow(unqualifiedName: String,
         throw new RuntimeException(s"output ${output.fullyQualifiedName} has no parent Scope") 
       }
       
-      new WorkflowOutput(output.locallyQualifiedName(this), wdlType, WdlExpression.fromString(locallyQualifiedName), output.ast, Option(this))
+      new WorkflowOutput(locallyQualifiedName, wdlType, WdlExpression.fromString(locallyQualifiedName), output.ast, Option(this))
     }
 
     def toWorkflowOutputs(scope: Scope) = {

--- a/src/test/scala/wdl4s/WorkflowSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowSpec.scala
@@ -167,37 +167,37 @@ class WorkflowSpec extends WordSpec with Matchers {
         "task wildcard",
         "main_task.*",
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2")
+          WorkflowOutputExpectation("main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
+          WorkflowOutputExpectation("main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2")
         ),
         Map(
-          "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
-          "main_workflow.main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8)))
+          "main_task.task_o1" -> WdlString("MainTaskOutputString"),
+          "main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8)))
         )
       ),
       WorkflowOutputTestCase(
         "aliased task wildcard",
         "main_task2.*",
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow.main_task2.task_o1", WdlStringType, "main_task2.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")
+          WorkflowOutputExpectation("main_workflow.main_task2.task_o1", WdlStringType, "main_task2.task_o1"),
+          WorkflowOutputExpectation("main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")
         ),
         Map(
-          "main_workflow.main_task2.task_o1" -> WdlString("MainTask2OutputString"),
-          "main_workflow.main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16)))
+          "main_task2.task_o1" -> WdlString("MainTask2OutputString"),
+          "main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16)))
         )
       ),
       WorkflowOutputTestCase(
         "sub task wildcard",
         "sub_task.*",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
-        Map("main_workflow.sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
+        Map("sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased sub task wildcard",
         "sub_task2.*",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
-        Map("main_workflow.sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
+        Map("sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
       ),
       
       /*  DIRECT OUTPUT REFERENCES  */
@@ -215,44 +215,44 @@ class WorkflowSpec extends WordSpec with Matchers {
       WorkflowOutputTestCase(
         "task output",
         "main_task.task_o1", 
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1")),
-        Map("main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1")),
+        Map("main_task.task_o1" -> WdlString("MainTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased task output",
         "main_task2.task_o2",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
-        Map("main_workflow.main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
+        Seq(WorkflowOutputExpectation("main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
+        Map("main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
       ),
       WorkflowOutputTestCase(
         "task output in scatter",
         "main_task_in_scatter.task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.main_task_in_scatter.task_o1", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
-        Map("main_workflow.main_task_in_scatter.task_o1" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
+        Seq(WorkflowOutputExpectation("main_workflow.main_task_in_scatter.task_o1", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
+        Map("main_task_in_scatter.task_o1" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
       ),
       WorkflowOutputTestCase(
         "sub task output",
         "sub_task.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
-        Map("main_workflow.sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
+        Map("sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
         ),
       WorkflowOutputTestCase(
         "aliased sub task output",
         "sub_task2.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
-        Map("main_workflow.sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
+        Map("sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
       ),
       WorkflowOutputTestCase(
         "sub workflow output",
         "sub_workflow.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_workflow.sub_o1", WdlStringType, "sub_workflow.sub_o1")),
-        Map("main_workflow.sub_workflow.sub_o1" -> WdlString("SubWorkflowOutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.sub_workflow.sub_o1", WdlStringType, "sub_workflow.sub_o1")),
+        Map("sub_workflow.sub_o1" -> WdlString("SubWorkflowOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased sub workflow output",
         "sub_workflow2.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_workflow.sub_workflow2.sub_o1", WdlStringType, "sub_workflow2.sub_o1")),
-        Map("main_workflow.sub_workflow2.sub_o1" -> WdlString("SubWorkflow2OutputString"))
+        Seq(WorkflowOutputExpectation("main_workflow.sub_workflow2.sub_o1", WdlStringType, "sub_workflow2.sub_o1")),
+        Map("sub_workflow2.sub_o1" -> WdlString("SubWorkflow2OutputString"))
       ),
 
       /*  DECLARATIVE SYNTAX  */
@@ -383,13 +383,13 @@ class WorkflowSpec extends WordSpec with Matchers {
         """main_task.*
           |String o1 = main_task.task_o1""".stripMargin,
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2"),
+          WorkflowOutputExpectation("main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
+          WorkflowOutputExpectation("main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2"),
           WorkflowOutputExpectation("main_workflow.o1", WdlStringType, "main_task.task_o1")
         ),
         Map(
-          "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
-          "main_workflow.main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8))),
+          "main_task.task_o1" -> WdlString("MainTaskOutputString"),
+          "main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8))),
           "o1" -> WdlString("MainTaskOutputString")
         )
       )
@@ -427,13 +427,13 @@ class WorkflowSpec extends WordSpec with Matchers {
         """.stripMargin
 
       val expectedDeclarations = Seq(
-        WorkflowOutputExpectation("w.w.t.o1", WdlStringType, "t.o1"),
-        WorkflowOutputExpectation("w.w.t.o2", WdlStringType, "t.o2")
+        WorkflowOutputExpectation("w.t.o1", WdlStringType, "t.o1"),
+        WorkflowOutputExpectation("w.t.o2", WdlStringType, "t.o2")
       )
       
       val expectedEvaluatedOutputs = Map(
-        "w.t.o1" -> WdlString("o1"),
-        "w.t.o2" -> WdlString("o2")
+        "t.o1" -> WdlString("o1"),
+        "t.o2" -> WdlString("o2")
       )
 
       val ns = WdlNamespaceWithWorkflow.load(wdl)


### PR DESCRIPTION
`output.locallyQualifiedName(this)` resulted in the workflow output unqualified name being `workflow_name.task_name.task_output_name`, which contains the workflow name and hence gives the wrong result when calling `fullyQualifiedName` on it.