### PR TITLE
Harmonize workflow outputs

### DIFF
--- a/src/main/scala/wdl4s/Task.scala
+++ b/src/main/scala/wdl4s/Task.scala
@@ -169,9 +169,9 @@ case class Task(name: String,
 
   def evaluateOutputs(inputs: EvaluatedTaskInputs,
                       wdlFunctions: WdlStandardLibraryFunctions,
-                      postMapper: WdlValue => Try[WdlValue] = v => Success(v)): Try[Map[LocallyQualifiedName, WdlValue]] = {
+                      postMapper: WdlValue => Try[WdlValue] = v => Success(v)): Try[Map[TaskOutput, WdlValue]] = {
     val fqnInputs = inputs map { case (d, v) => d.fullyQualifiedName -> v }
-    val evaluatedOutputs = outputs.foldLeft(Map.empty[Scope, Try[WdlValue]])((outputMap, output) => {
+    val evaluatedOutputs = outputs.foldLeft(Map.empty[TaskOutput, Try[WdlValue]])((outputMap, output) => {
       val currentOutputs = outputMap collect {
         case (outputName, value) if value.isSuccess => outputName.fullyQualifiedName -> value.get
       }
@@ -182,7 +182,7 @@ case class Task(name: String,
         case t: Throwable => Failure(new RuntimeException(s"Could not evaluate ${output.fullyQualifiedName} = ${output.requiredExpression.toWdlString}", t))
       }
       outputMap + jobOutput
-    }) map { case (k, v) => k.unqualifiedName -> v }
+    }) map { case (k, v) => k -> v }
 
     TryUtil.sequenceMap(evaluatedOutputs, "Failed to evaluate outputs.")
   }

--- a/src/main/scala/wdl4s/Workflow.scala
+++ b/src/main/scala/wdl4s/Workflow.scala
@@ -187,7 +187,7 @@ case class Workflow(unqualifiedName: String,
       val workflowOutput = output -> coerced
 
       outputMap + workflowOutput
-    }) map { case (k, v) => k.locallyQualifiedName(this) -> v }
+    }) map { case (k, v) => k.unqualifiedName -> v }
 
     TryUtil.sequenceMap(evaluatedOutputs, "Failed to evaluate workflow outputs.\n")
   }

--- a/src/main/scala/wdl4s/Workflow.scala
+++ b/src/main/scala/wdl4s/Workflow.scala
@@ -175,7 +175,7 @@ case class Workflow(unqualifiedName: String,
   def evaluateOutputs(knownInputs: WorkflowCoercedInputs,
                       wdlFunctions: WdlFunctions[WdlValue],
                       outputResolver: OutputResolver = NoOutputResolver,
-                      shards: Map[Scatter, Int] = Map.empty[Scatter, Int]): Try[Map[LocallyQualifiedName, WdlValue]] = {
+                      shards: Map[Scatter, Int] = Map.empty[Scatter, Int]): Try[Map[WorkflowOutput, WdlValue]] = {
     
     val evaluatedOutputs = outputs.foldLeft(Map.empty[WorkflowOutput, Try[WdlValue]])((outputMap, output) => {
       val currentOutputs = outputMap collect {
@@ -187,7 +187,7 @@ case class Workflow(unqualifiedName: String,
       val workflowOutput = output -> coerced
 
       outputMap + workflowOutput
-    }) map { case (k, v) => k.unqualifiedName -> v }
+    }) map { case (k, v) => k -> v }
 
     TryUtil.sequenceMap(evaluatedOutputs, "Failed to evaluate workflow outputs.\n")
   }

--- a/src/main/scala/wdl4s/types/WdlArrayType.scala
+++ b/src/main/scala/wdl4s/types/WdlArrayType.scala
@@ -40,7 +40,7 @@ sealed trait WdlArrayType extends WdlType {
   }
 
   override def isCoerceableFrom(otherType: WdlType): Boolean = otherType match {
-    case WdlArrayType(otherMemberType) => otherMemberType == WdlAnyType || otherMemberType.isCoerceableFrom(memberType)
+    case WdlArrayType(otherMemberType) => otherMemberType == WdlAnyType || memberType.isCoerceableFrom(otherMemberType)
     case _ => false
   }
 

--- a/src/main/scala/wdl4s/types/WdlArrayType.scala
+++ b/src/main/scala/wdl4s/types/WdlArrayType.scala
@@ -40,7 +40,7 @@ sealed trait WdlArrayType extends WdlType {
   }
 
   override def isCoerceableFrom(otherType: WdlType): Boolean = otherType match {
-    case WdlArrayType(otherMemberType) => otherMemberType == WdlAnyType || memberType.isCoerceableFrom(otherMemberType)
+    case WdlArrayType(otherMemberType) => memberType.isCoerceableFrom(otherMemberType)
     case _ => false
   }
 

--- a/src/main/scala/wdl4s/types/WdlArrayType.scala
+++ b/src/main/scala/wdl4s/types/WdlArrayType.scala
@@ -40,7 +40,7 @@ sealed trait WdlArrayType extends WdlType {
   }
 
   override def isCoerceableFrom(otherType: WdlType): Boolean = otherType match {
-    case WdlArrayType(otherMemberType) => memberType.isCoerceableFrom(otherMemberType)
+    case WdlArrayType(otherMemberType) => otherMemberType == WdlAnyType || memberType.isCoerceableFrom(otherMemberType)
     case _ => false
   }
 

--- a/src/test/scala/wdl4s/TaskSpec.scala
+++ b/src/test/scala/wdl4s/TaskSpec.scala
@@ -146,9 +146,9 @@ class TaskSpec extends WdlTest {
       outputs.isSuccess shouldBe true
       val successfulOutputs = outputs.get
       successfulOutputs.size shouldBe 3
-      successfulOutputs.find(_._1 == "o").get._2 shouldBe WdlString("input")
-      successfulOutputs.find(_._1 == "o2").get._2 shouldBe WdlString("input")
-      successfulOutputs.find(_._1 == "o3").get._2 shouldBe WdlString("o3")
+      successfulOutputs.find(_._1.unqualifiedName == "o").get._2 shouldBe WdlString("input")
+      successfulOutputs.find(_._1.unqualifiedName == "o2").get._2 shouldBe WdlString("input")
+      successfulOutputs.find(_._1.unqualifiedName == "o3").get._2 shouldBe WdlString("o3")
     }
 
     "instantiate command (4)" in {

--- a/src/test/scala/wdl4s/WorkflowSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowSpec.scala
@@ -172,8 +172,8 @@ class WorkflowSpec extends WordSpec with Matchers {
           WorkflowOutputExpectation("main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2")
         ),
         Map(
-          "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
-          "main_workflow.main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8)))
+          "main_task.task_o1" -> WdlString("MainTaskOutputString"),
+          "main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8)))
         )
       ),
       WorkflowOutputTestCase(
@@ -184,8 +184,8 @@ class WorkflowSpec extends WordSpec with Matchers {
           WorkflowOutputExpectation("main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")
         ),
         Map(
-          "main_workflow.main_task2.task_o1" -> WdlString("MainTask2OutputString"),
-          "main_workflow.main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16)))
+          "main_task2.task_o1" -> WdlString("MainTask2OutputString"),
+          "main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16)))
         )
       ),
       WorkflowOutputTestCase(
@@ -389,9 +389,9 @@ class WorkflowSpec extends WordSpec with Matchers {
           WorkflowOutputExpectation("o1", WdlStringType, "main_task.task_o1")
         ),
         Map(
-          "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
-          "main_workflow.main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8))),
-          "main_workflow.o1" -> WdlString("MainTaskOutputString")
+          "main_task.task_o1" -> WdlString("MainTaskOutputString"),
+          "main_task.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(8))),
+          "o1" -> WdlString("MainTaskOutputString")
         )
       )
     ) foreach { test =>
@@ -433,8 +433,8 @@ class WorkflowSpec extends WordSpec with Matchers {
       )
       
       val expectedEvaluatedOutputs = Map(
-        "w.t.o1" -> WdlString("o1"),
-        "w.t.o2" -> WdlString("o2")
+        "t.o1" -> WdlString("o1"),
+        "t.o2" -> WdlString("o2")
       )
 
       val ns = WdlNamespaceWithWorkflow.load(wdl)

--- a/src/test/scala/wdl4s/WorkflowSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowSpec.scala
@@ -114,13 +114,14 @@ class WorkflowSpec extends WordSpec with Matchers {
       }
     }
 
-    case class WorkflowOutputExpectation(fullyQualifiedName: FullyQualifiedName, wdlType: WdlType, sourceString: String)
+    case class WorkflowOutputExpectation(unqualifiedName: FullyQualifiedName, wdlType: WdlType, sourceString: String)
 
     implicit val workflowOutputEquality = new Equality[WorkflowOutput] {
       override def areEqual(src: WorkflowOutput, expectation: Any): Boolean = {
         expectation match {
           case output: WorkflowOutputExpectation =>
-            output.fullyQualifiedName == src.fullyQualifiedName &&
+            output.unqualifiedName == src.unqualifiedName &&
+            "main_workflow." + output.unqualifiedName == src.locallyQualifiedName(src.parent.get) &&
               output.wdlType.toWdlString == src.wdlType.toWdlString &&
               output.sourceString == src.requiredExpression.toWdlString
           case _ => false
@@ -167,8 +168,8 @@ class WorkflowSpec extends WordSpec with Matchers {
         "task wildcard",
         "main_task.*",
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2")
+          WorkflowOutputExpectation("main_task.task_o1", WdlStringType, "main_task.task_o1"),
+          WorkflowOutputExpectation("main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2")
         ),
         Map(
           "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
@@ -179,8 +180,8 @@ class WorkflowSpec extends WordSpec with Matchers {
         "aliased task wildcard",
         "main_task2.*",
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_task2.task_o1", WdlStringType, "main_task2.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")
+          WorkflowOutputExpectation("main_task2.task_o1", WdlStringType, "main_task2.task_o1"),
+          WorkflowOutputExpectation("main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")
         ),
         Map(
           "main_workflow.main_task2.task_o1" -> WdlString("MainTask2OutputString"),
@@ -190,14 +191,14 @@ class WorkflowSpec extends WordSpec with Matchers {
       WorkflowOutputTestCase(
         "sub task wildcard",
         "sub_task.*",
-        Seq(WorkflowOutputExpectation("main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
-        Map("main_workflow.sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
+        Seq(WorkflowOutputExpectation("sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
+        Map("sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased sub task wildcard",
         "sub_task2.*",
-        Seq(WorkflowOutputExpectation("main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
-        Map("main_workflow.sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
+        Seq(WorkflowOutputExpectation("sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
+        Map("sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
       ),
       
       /*  DIRECT OUTPUT REFERENCES  */
@@ -214,45 +215,45 @@ class WorkflowSpec extends WordSpec with Matchers {
        */
       WorkflowOutputTestCase(
         "task output",
-        "main_task.task_o1", 
-        Seq(WorkflowOutputExpectation("main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1")),
-        Map("main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"))
+        "main_task.task_o1",
+        Seq(WorkflowOutputExpectation("main_task.task_o1", WdlStringType, "main_task.task_o1")),
+        Map("main_task.task_o1" -> WdlString("MainTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased task output",
         "main_task2.task_o2",
-        Seq(WorkflowOutputExpectation("main_workflow.main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
-        Map("main_workflow.main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
+        Seq(WorkflowOutputExpectation("main_task2.task_o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
+        Map("main_task2.task_o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
       ),
       WorkflowOutputTestCase(
         "task output in scatter",
         "main_task_in_scatter.task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.main_task_in_scatter.task_o1", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
-        Map("main_workflow.main_task_in_scatter.task_o1" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
+        Seq(WorkflowOutputExpectation("main_task_in_scatter.task_o1", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
+        Map("main_task_in_scatter.task_o1" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
       ),
       WorkflowOutputTestCase(
         "sub task output",
         "sub_task.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
-        Map("main_workflow.sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
+        Seq(WorkflowOutputExpectation("sub_task.sub_task_o1", WdlStringType, "sub_task.sub_task_o1")),
+        Map("sub_task.sub_task_o1" -> WdlString("SubTaskOutputString"))
         ),
       WorkflowOutputTestCase(
         "aliased sub task output",
         "sub_task2.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
-        Map("main_workflow.sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
+        Seq(WorkflowOutputExpectation("sub_task2.sub_task_o1", WdlStringType, "sub_task2.sub_task_o1")),
+        Map("sub_task2.sub_task_o1" -> WdlString("SubTask2OutputString"))
       ),
       WorkflowOutputTestCase(
         "sub workflow output",
         "sub_workflow.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.sub_workflow.sub_o1", WdlStringType, "sub_workflow.sub_o1")),
-        Map("main_workflow.sub_workflow.sub_o1" -> WdlString("SubWorkflowOutputString"))
+        Seq(WorkflowOutputExpectation("sub_workflow.sub_o1", WdlStringType, "sub_workflow.sub_o1")),
+        Map("sub_workflow.sub_o1" -> WdlString("SubWorkflowOutputString"))
       ),
       WorkflowOutputTestCase(
         "aliased sub workflow output",
         "sub_workflow2.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.sub_workflow2.sub_o1", WdlStringType, "sub_workflow2.sub_o1")),
-        Map("main_workflow.sub_workflow2.sub_o1" -> WdlString("SubWorkflow2OutputString"))
+        Seq(WorkflowOutputExpectation("sub_workflow2.sub_o1", WdlStringType, "sub_workflow2.sub_o1")),
+        Map("sub_workflow2.sub_o1" -> WdlString("SubWorkflow2OutputString"))
       ),
 
       /*  DECLARATIVE SYNTAX  */
@@ -281,38 +282,38 @@ class WorkflowSpec extends WordSpec with Matchers {
       WorkflowOutputTestCase(
         "declarative task output",
         "String o1 = main_task.task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.o1", WdlStringType, "main_task.task_o1")),
-        Map("main_workflow.o1" -> WdlString("MainTaskOutputString"))
+        Seq(WorkflowOutputExpectation("o1", WdlStringType, "main_task.task_o1")),
+        Map("o1" -> WdlString("MainTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "declarative aliased task output",
         "Array[Int] o2 = main_task2.task_o2",
-        Seq(WorkflowOutputExpectation("main_workflow.o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
-        Map("main_workflow.o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
+        Seq(WorkflowOutputExpectation("o2", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
+        Map("o2" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
       ),
       WorkflowOutputTestCase(
         "declarative sub task output",
         "String o3 = sub_task.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.o3", WdlStringType, "sub_task.sub_task_o1")),
-        Map("main_workflow.o3" -> WdlString("SubTaskOutputString"))
+        Seq(WorkflowOutputExpectation("o3", WdlStringType, "sub_task.sub_task_o1")),
+        Map("o3" -> WdlString("SubTaskOutputString"))
       ),
       WorkflowOutputTestCase(
         "declarative aliased sub task output",
         "String o4 = sub_task2.sub_task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.o4", WdlStringType, "sub_task2.sub_task_o1")),
-        Map("main_workflow.o4" -> WdlString("SubTask2OutputString"))
+        Seq(WorkflowOutputExpectation("o4", WdlStringType, "sub_task2.sub_task_o1")),
+        Map("o4" -> WdlString("SubTask2OutputString"))
       ),
       WorkflowOutputTestCase(
         "declarative sub workflow output",
         "String o5 = sub_workflow.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.o5", WdlStringType, "sub_workflow.sub_o1")),
-        Map("main_workflow.o5" -> WdlString("SubWorkflowOutputString"))
+        Seq(WorkflowOutputExpectation("o5", WdlStringType, "sub_workflow.sub_o1")),
+        Map("o5" -> WdlString("SubWorkflowOutputString"))
       ),
       WorkflowOutputTestCase(
         "declarative aliased sub workflow output",
         "String o6 = sub_workflow2.sub_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.o6", WdlStringType, "sub_workflow2.sub_o1")),
-        Map("main_workflow.o6" -> WdlString("SubWorkflow2OutputString"))
+        Seq(WorkflowOutputExpectation("o6", WdlStringType, "sub_workflow2.sub_o1")),
+        Map("o6" -> WdlString("SubWorkflow2OutputString"))
       ),
       WorkflowOutputTestCase(
         "declarative reference to previous output",
@@ -320,61 +321,61 @@ class WorkflowSpec extends WordSpec with Matchers {
           |String o7 = o1
         """.stripMargin,
         Seq(
-          WorkflowOutputExpectation("main_workflow.o1", WdlStringType, "\"hey\""),
-          WorkflowOutputExpectation("main_workflow.o7", WdlStringType, "o1")
+          WorkflowOutputExpectation("o1", WdlStringType, "\"hey\""),
+          WorkflowOutputExpectation("o7", WdlStringType, "o1")
         ),
         Map(
-          "main_workflow.o1" -> WdlString("hey"),
-          "main_workflow.o7" -> WdlString("hey")
+          "o1" -> WdlString("hey"),
+          "o7" -> WdlString("hey")
         )
       ),
       WorkflowOutputTestCase(
         "declarative reference to empty input declaration",
         "String o8 = workflow_input",
-        Seq(WorkflowOutputExpectation("main_workflow.o8", WdlStringType, "workflow_input")),
-        Map("main_workflow.o8" -> WdlString("workflow_input"))
+        Seq(WorkflowOutputExpectation("o8", WdlStringType, "workflow_input")),
+        Map("o8" -> WdlString("workflow_input"))
       ),
       WorkflowOutputTestCase(
         "declarative reference to provided input declaration",
         "String o9 = workflow_input2",
-        Seq(WorkflowOutputExpectation("main_workflow.o9", WdlStringType, "workflow_input2")),
-        Map("main_workflow.o9" -> WdlString("workflow_input2"))
+        Seq(WorkflowOutputExpectation("o9", WdlStringType, "workflow_input2")),
+        Map("o9" -> WdlString("workflow_input2"))
       ),
       WorkflowOutputTestCase(
         "declarative coercion",
         "File o10 = workflow_input2",
-        Seq(WorkflowOutputExpectation("main_workflow.o10", WdlFileType, "workflow_input2")),
-        Map("main_workflow.o10" -> WdlSingleFile("workflow_input2"))
+        Seq(WorkflowOutputExpectation("o10", WdlFileType, "workflow_input2")),
+        Map("o10" -> WdlSingleFile("workflow_input2"))
       ),
       WorkflowOutputTestCase(
         "declarative complex type",
         "Array[Int] o11 = main_task2.task_o2",
-        Seq(WorkflowOutputExpectation("main_workflow.o11", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
-        Map("main_workflow.o11" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
+        Seq(WorkflowOutputExpectation("o11", WdlArrayType(WdlIntegerType), "main_task2.task_o2")),
+        Map("o11" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(WdlInteger(16))))
       ),
       WorkflowOutputTestCase(
         "inline declaration with complex type",
         "Map[Int, String] o12 = {1: \"1\"}",
-        Seq(WorkflowOutputExpectation("main_workflow.o12", WdlMapType(WdlIntegerType, WdlStringType), "{1:\"1\"}")),
-        Map("main_workflow.o12" -> WdlMap(WdlMapType(WdlIntegerType,WdlStringType), Map(WdlInteger(1) -> WdlString("1"))))
+        Seq(WorkflowOutputExpectation("o12", WdlMapType(WdlIntegerType, WdlStringType), "{1:\"1\"}")),
+        Map("o12" -> WdlMap(WdlMapType(WdlIntegerType,WdlStringType), Map(WdlInteger(1) -> WdlString("1"))))
       ),
       WorkflowOutputTestCase(
         "simple expression",
         """String o13 = "hello" + " " + "world !"""",
-        Seq(WorkflowOutputExpectation("main_workflow.o13", WdlStringType, """"hello" + " " + "world !"""")),
-        Map("main_workflow.o13" -> WdlString("hello world !"))
+        Seq(WorkflowOutputExpectation("o13", WdlStringType, """"hello" + " " + "world !"""")),
+        Map("o13" -> WdlString("hello world !"))
       ),
       WorkflowOutputTestCase(
         "declarative task output in scatter",
         "Array[String] o14 = main_task_in_scatter.task_o1",
-        Seq(WorkflowOutputExpectation("main_workflow.o14", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
-        Map("main_workflow.o14" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
+        Seq(WorkflowOutputExpectation("o14", WdlArrayType(WdlStringType), "main_task_in_scatter.task_o1")),
+        Map("o14" -> WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("MainTaskOutputString"))))
       ),
       WorkflowOutputTestCase(
         "optional value",
         "String? o15 = optionalValue",
-        Seq(WorkflowOutputExpectation("main_workflow.o15", WdlOptionalType(WdlStringType), "optionalValue")),
-        Map("main_workflow.o15" -> WdlOptionalValue(WdlString("optional")))
+        Seq(WorkflowOutputExpectation("o15", WdlOptionalType(WdlStringType), "optionalValue")),
+        Map("o15" -> WdlOptionalValue(WdlString("optional")))
       ),
       
       /* LEGACY SYNTAX FOLLOWED BY NEW SYNTAX */
@@ -383,9 +384,9 @@ class WorkflowSpec extends WordSpec with Matchers {
         """main_task.*
           |String o1 = main_task.task_o1""".stripMargin,
         Seq(
-          WorkflowOutputExpectation("main_workflow.main_task.task_o1", WdlStringType, "main_task.task_o1"),
-          WorkflowOutputExpectation("main_workflow.main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2"),
-          WorkflowOutputExpectation("main_workflow.o1", WdlStringType, "main_task.task_o1")
+          WorkflowOutputExpectation("main_task.task_o1", WdlStringType, "main_task.task_o1"),
+          WorkflowOutputExpectation("main_task.task_o2", WdlArrayType(WdlIntegerType), "main_task.task_o2"),
+          WorkflowOutputExpectation("o1", WdlStringType, "main_task.task_o1")
         ),
         Map(
           "main_workflow.main_task.task_o1" -> WdlString("MainTaskOutputString"),
@@ -421,14 +422,14 @@ class WorkflowSpec extends WordSpec with Matchers {
           |     String o2 = "b"
           |  }
           |}
-          |workflow w {
+          |workflow main_workflow {
           |  call t
           |}
         """.stripMargin
 
       val expectedDeclarations = Seq(
-        WorkflowOutputExpectation("w.t.o1", WdlStringType, "t.o1"),
-        WorkflowOutputExpectation("w.t.o2", WdlStringType, "t.o2")
+        WorkflowOutputExpectation("t.o1", WdlStringType, "t.o1"),
+        WorkflowOutputExpectation("t.o2", WdlStringType, "t.o2")
       )
       
       val expectedEvaluatedOutputs = Map(

--- a/src/test/scala/wdl4s/WorkflowSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowSpec.scala
@@ -138,7 +138,7 @@ class WorkflowSpec extends WordSpec with Matchers {
 
       val evaluatedOutputs = ns.workflow.evaluateOutputs(workflowInputs, NoFunctions, outputResolver)
       evaluatedOutputs match {
-        case Success(v) => v should contain theSameElementsAs evaluationExpectations
+        case Success(v) => v map { case (output, outputValue) => output.unqualifiedName -> outputValue } should contain theSameElementsAs evaluationExpectations
         case Failure(e) => fail(e)
       }
     }

--- a/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
+++ b/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
@@ -114,7 +114,7 @@ class WdlArrayTypeSpec extends FlatSpec with Matchers  {
   }
 
   List(WdlStringType, WdlArrayType(WdlIntegerType), WdlPairType(WdlIntegerType, WdlPairType(WdlIntegerType, WdlIntegerType)), WdlOptionalType(WdlStringType)) foreach { desiredMemberType =>
-    it should s"be able to construct an empty Array[${desiredMemberType.toWdlString}] value" ignore {
+    it should s"be able to construct an empty Array[${desiredMemberType.toWdlString}] value" in {
       def noLookup(String: String): WdlValue = fail("No identifiers should be looked up in this test")
 
       val desiredArrayType = WdlArrayType(desiredMemberType)

--- a/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
+++ b/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
@@ -114,7 +114,7 @@ class WdlArrayTypeSpec extends FlatSpec with Matchers  {
   }
 
   List(WdlStringType, WdlArrayType(WdlIntegerType), WdlPairType(WdlIntegerType, WdlPairType(WdlIntegerType, WdlIntegerType)), WdlOptionalType(WdlStringType)) foreach { desiredMemberType =>
-    it should s"be able to construct an empty Array[${desiredMemberType.toWdlString}] value" in {
+    it should s"be able to construct an empty Array[${desiredMemberType.toWdlString}] value" ignore {
       def noLookup(String: String): WdlValue = fail("No identifiers should be looked up in this test")
 
       val desiredArrayType = WdlArrayType(desiredMemberType)


### PR DESCRIPTION
The last few fixes introduced some incompatibilities between how the workflow outputs look for the old and new syntax. This squares things up and allow Cromwell + other users of wdl4s to get coherent results in both cases.

Workflow outputs unqualified names are now as they should for both old and new syntax: 

- For the old syntax, the unqualified name of the workflow output will be of the form `task_name.output_name`.

```
workflow wf {
  outputs {
    task_name.output_name # will create a WorkflowOutput declaration with "task_name.output_name" as unqualified name
  }
}
```

- For the new syntax, the unqualified name of the workflow output will be the one given in the wdl

```
workflow wf {
  outputs {
    String my_wf_output # will create a WorkflowOutput declaration with "my_wf_output" as unqualified name
  }
}
```

- In order to get a workflow output qualified name containing the workflow name as well, one can 
```
// Assuming workflow is a Workflow object
val outputs = workflow.outputs map { _.locallyQualifiedName(workflow) }
```

- output evaluation function (for task and workflow) now return a `Map[TaskOutput, WdlValue]` and `Map[WorkflowOutput, WdlValue]` respectively. This allows the caller to manipulate the workflow output qualified name as they please for display etc...

- The `WdlArrayType` change is a fix from @cjllanwarne 