### PR TITLE
Prioritize declaration expressions above declarations.

### DIFF
--- a/src/main/scala/wdl4s/Call.scala
+++ b/src/main/scala/wdl4s/Call.scala
@@ -180,7 +180,7 @@ sealed abstract class Call(val alias: Option[String],
         parentLookup <- Try(parent.lookupFunction(inputs, wdlFunctions, outputResolver, shards, relativeTo)(name))
       } yield parentLookup
 
-      val resolutions = Seq(inputMappingsLookup, declarationLookup, declarationExprLookup, taskParentResolution)
+      val resolutions = Seq(inputMappingsLookup, declarationExprLookup, declarationLookup, taskParentResolution)
 
       resolutions.collectFirst({ case Success(value) => value}) match {
         case Some(value) => value


### PR DESCRIPTION
The existing order of lookup resolvers gave the declaration resolver precedence over the declaration expression resolver.  But in the case of an initialized optional variable, the declaration resolver does not fail but rather returns an empty optional.  This non-failing result took precedence over the correct result in the declaration expression resolver.  These changes only flip the precedence of the resolvers.