### PR TITLE
Build updates.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
-# This file can always be added to, line additions should never collide.
-CHANGELOG.MD merge=union
-
 # These files are text and should be normalized (Convert crlf => lf)
 *.scala text
 *.MD text

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ versionWithGit ++ versionSettings
 
 val sprayJsonV = "1.3.2"
 
-val lenthallV = "0.20"
+val lenthallV = "0.21-e1b7822-SNAP"
 
 resolvers ++= List(
   "Broad Artifactory Releases" at "https://artifactory.broadinstitute.org/artifactory/libs-release/"
@@ -49,7 +49,8 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-lang3" % "3.4",
   "com.github.pathikrit" %% "better-files" % "2.16.0",
   //---------- Test libraries -------------------//
-  "org.scalatest" %% "scalatest" % "3.0.0" % Test
+  "org.scalatest" %% "scalatest" % "3.0.1" % Test,
+  "org.pegdown" % "pegdown" % "1.6.0" % Test
 )
 
 // The reason why -Xmax-classfile-name is set is because this will fail
@@ -60,4 +61,4 @@ libraryDependencies ++= Seq(
 // https://github.com/scala/pickling/issues/10
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xmax-classfile-name", "200")
 
-testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDSI")
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDSI", "-h", "target/test-reports")

--- a/src/main/scala/wdl4s/examples/ex1.scala
+++ b/src/main/scala/wdl4s/examples/ex1.scala
@@ -11,7 +11,7 @@ object ex1 {
     | call a
     |}""".stripMargin
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
 
     println(s"Workflow: ${ns.workflow.unqualifiedName}")
     ns.workflow.calls foreach {call =>

--- a/src/main/scala/wdl4s/examples/ex2.scala
+++ b/src/main/scala/wdl4s/examples/ex2.scala
@@ -22,7 +22,7 @@ object ex2 {
       }
     }
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl, resolver _).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq(resolver _)).get
 
     ns.tasks foreach {task =>
       println(s"Task: ${task.name}")

--- a/src/main/scala/wdl4s/examples/ex3.scala
+++ b/src/main/scala/wdl4s/examples/ex3.scala
@@ -20,7 +20,7 @@ object ex3 {
       }
     }
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl, resolver _).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq(resolver _)).get
 
     ns.tasks foreach {task =>
       println(s"Task: ${task.name}")

--- a/src/main/scala/wdl4s/examples/ex4.scala
+++ b/src/main/scala/wdl4s/examples/ex4.scala
@@ -13,7 +13,7 @@ object ex4 {
       | call a as b
       |}""".stripMargin
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
 
     println(ns.resolve("wf.a")) // resolves to Call object for `call a`
     println(ns.resolve("wf.b")) // resolves to Call object for `call a as b`

--- a/src/main/scala/wdl4s/examples/ex5.scala
+++ b/src/main/scala/wdl4s/examples/ex5.scala
@@ -20,7 +20,7 @@ object ex5 {
       | call b {input: s=a.procs}
       |}""".stripMargin
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
 
     Seq(ns.resolve("wf.a"), ns.resolve("wf.b")) foreach {
       case Some(c: TaskCall) => println(s"Call '${c.fullyQualifiedName}' prerequisites: ${c.upstream}")

--- a/src/main/scala/wdl4s/examples/ex6.scala
+++ b/src/main/scala/wdl4s/examples/ex6.scala
@@ -13,7 +13,7 @@ object ex6 {
       |  String c = "hello " + other_variable
       |}""".stripMargin
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
     def lookup(name: String): WdlValue = {
       name match {
         case "variable" => WdlString("world")
@@ -22,7 +22,7 @@ object ex6 {
     }
     ns.workflow.declarations foreach { decl =>
       val value = decl.expression.get.evaluate(lookup, NoFunctions)
-      println(s"Declaration '${decl.toWdlString}' evaluates to: ${value}")
+      println(s"Declaration '${decl.toWdlString}' evaluates to: $value")
     }
   }
 }

--- a/src/main/scala/wdl4s/examples/ex7.scala
+++ b/src/main/scala/wdl4s/examples/ex7.scala
@@ -21,7 +21,7 @@ object ex7 {
       |  call a
       |}""".stripMargin
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
     val inputs = Map(
       "prefix" -> WdlString("some_prefix"),
       "ints" -> WdlArray(WdlArrayType(WdlIntegerType), Seq(1,2,3,4,5).map(WdlInteger(_)))

--- a/src/test/scala/wdl4s/AdvancedInterpolationSpec.scala
+++ b/src/test/scala/wdl4s/AdvancedInterpolationSpec.scala
@@ -29,7 +29,7 @@ class AdvancedInterpolationSpec extends FlatSpec with Matchers {
       |}
     """.stripMargin
 
-  val namespace = WdlNamespaceWithWorkflow.load(wdl).get
+  val namespace = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
 
   it should "be able to resolve interpolated strings within interpolated strings" in {
     val testCall = namespace.workflow.taskCalls.find(_.unqualifiedName == "test") getOrElse {

--- a/src/test/scala/wdl4s/CallSpec.scala
+++ b/src/test/scala/wdl4s/CallSpec.scala
@@ -11,7 +11,7 @@ import scala.util.{Failure, Success, Try}
 class CallSpec extends WordSpec with Matchers {
 
   "evaluate its declarations" in {
-    val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.TaskDeclarationsWdl.wdlSource()).get
+    val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.TaskDeclarationsWdl.wdlSource(), Seq.empty).get
     val callT = namespace.calls.find(_.unqualifiedName == "t").get
     val callT2 = namespace.calls.find(_.unqualifiedName == "t2").get
     val callV = namespace.calls.find(_.unqualifiedName == "v").get
@@ -109,7 +109,7 @@ class CallSpec extends WordSpec with Matchers {
         |}
       """.stripMargin
 
-    val ns = WdlNamespaceWithWorkflow.load(wdl, importResolver = (uri: String) => subWorkflow).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq((_: String) => subWorkflow)).get
     ns.workflow.workflowCalls.size shouldBe 1
     ns.workflow.taskCalls.size shouldBe 1
   }

--- a/src/test/scala/wdl4s/DeclarationSpec.scala
+++ b/src/test/scala/wdl4s/DeclarationSpec.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success}
 
 class DeclarationSpec extends FlatSpec with Matchers {
   lazy val wdlSource = (new SampleWdl.DeclarationsWdl).wdlSource()
-  lazy val namespace = WdlNamespaceWithWorkflow.load(wdlSource).get
+  lazy val namespace = WdlNamespaceWithWorkflow.load(wdlSource, Seq.empty).get
 
   "A Workflow with declarations" should "have declarations defined properly" in {
     namespace.workflow.declarations.size shouldEqual 4
@@ -181,7 +181,7 @@ class DeclarationSpec extends FlatSpec with Matchers {
                  |    }
                  |}
             """.stripMargin
-    val ns = WdlNamespaceWithWorkflow.load(wdl).get
+    val ns = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
     ns.staticDeclarationsRecursive(Map.empty[String, WdlValue], NoFunctions) match {
       case Failure(ex) => fail("Expected all declarations to be statically evaluable", ex)
       case Success(values) =>

--- a/src/test/scala/wdl4s/PrerequisiteScopesSpec.scala
+++ b/src/test/scala/wdl4s/PrerequisiteScopesSpec.scala
@@ -4,7 +4,7 @@ import wdl4s.SampleWdl.ScatterWdl
 import org.scalatest.{FlatSpec, Matchers}
 
 class PrerequisiteScopesSpec extends FlatSpec with Matchers {
-  val namespace = WdlNamespaceWithWorkflow.load((new ScatterWdl).wdlSource()).get
+  val namespace = WdlNamespaceWithWorkflow.load((new ScatterWdl).wdlSource(), Seq.empty).get
   val workflow = namespace.workflow
   val allCalls = workflow.calls
   val allScatters = workflow.scatters

--- a/src/test/scala/wdl4s/RuntimeAttributeSpec.scala
+++ b/src/test/scala/wdl4s/RuntimeAttributeSpec.scala
@@ -74,8 +74,8 @@ object RuntimeAttributeSpec {
     """.stripMargin
 
   class RuntimeAttributeSpec extends FlatSpec with Matchers with EitherValues {
-    val NamespaceWithRuntime = WdlNamespaceWithWorkflow.load(WorkflowWithRuntime).get
-    val NamespaceWithoutRuntime = WdlNamespaceWithWorkflow.load(WorkflowWithoutRuntime).get
+    val NamespaceWithRuntime = WdlNamespaceWithWorkflow.load(WorkflowWithRuntime, Seq.empty).get
+    val NamespaceWithoutRuntime = WdlNamespaceWithWorkflow.load(WorkflowWithoutRuntime, Seq.empty).get
 
     "WDL file with runtime attributes" should "have attribute maps" in {
       NamespaceWithRuntime.tasks.forall(_.runtimeAttributes.attrs.nonEmpty) should be(true)

--- a/src/test/scala/wdl4s/SameNameParametersSpec.scala
+++ b/src/test/scala/wdl4s/SameNameParametersSpec.scala
@@ -12,7 +12,7 @@ class SameNameParametersSpec extends FlatSpec with Matchers {
        |  command { ./script ${x} ${x} ${x} }
        |}
        |workflow wf { call test }
-     """.stripMargin
+     """.stripMargin, Seq.empty
   ).get
   val task = namespace1.findTask("test").get
 

--- a/src/test/scala/wdl4s/ScopeSpec.scala
+++ b/src/test/scala/wdl4s/ScopeSpec.scala
@@ -5,7 +5,7 @@ import wdl4s.AstTools.AstNodeName
 import wdl4s.parser.WdlParser.Ast
 
 class ScopeSpec extends FlatSpec with Matchers {
-  val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.NestedScatterWdl.wdlSource()).get
+  val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.NestedScatterWdl.wdlSource(), Seq.empty).get
 
   it should "throw an exception if trying to re-assign children on a scope" in {
     the [UnsupportedOperationException] thrownBy { namespace.workflow.children = Seq.empty } should have message "children is write-once"

--- a/src/test/scala/wdl4s/TaskSpec.scala
+++ b/src/test/scala/wdl4s/TaskSpec.scala
@@ -101,7 +101,7 @@ class TaskSpec extends WdlTest {
 
     s"fail to instantiate command if missing a required input" in {
       paramTestTask.instantiateCommand(paramTestTask.inputsFromMap(Map("param_test.a" -> WdlString("a_val"))), NoFunctions) match {
-        case Failure(f) => // expected
+        case Failure(_) => // expected
         case _ => fail("Expected an exception")
       }
     }
@@ -115,7 +115,7 @@ class TaskSpec extends WdlTest {
         "param_test.e" -> WdlArray(WdlArrayType(WdlIntegerType), Seq())
       )
       paramTestTask.instantiateCommand(paramTestTask.inputsFromMap(inputs), NoFunctions) match {
-        case Failure(f) => // expected
+        case Failure(_) => // expected
         case _ => fail("Expected an exception")
       }
     }
@@ -139,7 +139,7 @@ class TaskSpec extends WdlTest {
         """.
           stripMargin
 
-      val namespace = WdlNamespaceWithWorkflow.load(wdl).get
+      val namespace = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
       val callT = namespace.taskCalls.find(_.unqualifiedName == "t").get
       val callInputs = Map(callT.task.declarations.head -> WdlString("input"))
       val outputs = callT.task.evaluateOutputs(callInputs, NoFunctions)
@@ -152,7 +152,7 @@ class TaskSpec extends WdlTest {
     }
 
     "instantiate command (4)" in {
-      val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.TaskDeclarationsWdl.wdlSource()).get
+      val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.TaskDeclarationsWdl.wdlSource(), Seq.empty).get
       val callV = namespace.taskCalls.find(_.unqualifiedName == "v").get
       val inputs = callV.task.inputsFromMap(
         Map(

--- a/src/test/scala/wdl4s/ThreeStepImportNamespaceSpec.scala
+++ b/src/test/scala/wdl4s/ThreeStepImportNamespaceSpec.scala
@@ -63,7 +63,7 @@ class ThreeStepImportNamespaceSpec extends FlatSpec with Matchers {
     }
   }
 
-  val namespace = WdlNamespaceWithWorkflow.load(workflowWdl, resolver _).get
+  val namespace = WdlNamespaceWithWorkflow.load(workflowWdl, Seq(resolver _)).get
 
 
   "WDL file with imports" should "Have 0 tasks (3 tasks are in separate namespace)" in {

--- a/src/test/scala/wdl4s/ThreeStepImportSpec.scala
+++ b/src/test/scala/wdl4s/ThreeStepImportSpec.scala
@@ -63,7 +63,7 @@ class ThreeStepImportSpec extends FlatSpec with Matchers {
     }
   }
 
-  val namespace = WdlNamespaceWithWorkflow.load(workflowWdl, resolver _).get
+  val namespace = WdlNamespaceWithWorkflow.load(workflowWdl, Seq(resolver _)).get
 
   "WDL file with imports" should "Have 3 tasks" in {
     namespace.tasks.size shouldEqual 0

--- a/src/test/scala/wdl4s/WdlTest.scala
+++ b/src/test/scala/wdl4s/WdlTest.scala
@@ -5,7 +5,8 @@ import org.scalatest.{Matchers, WordSpecLike}
 
 trait WdlTest extends Matchers with WordSpecLike {
   def resolver(root: File)(relPath: String): String = (root / relPath).contentAsString
-  def loadWdlFile(wdlFile: File) = WdlNamespaceWithWorkflow.load(wdlFile.path, resolver(wdlFile / "..") _).get
+  def loadWdlFile(wdlFile: File) =
+    WdlNamespaceWithWorkflow.load(wdlFile.contentAsString, Seq(resolver(wdlFile / "..") _)).get
   def getTask(ns: WdlNamespace, name: String): Task = ns.tasks.find(_.unqualifiedName == name).get
   def getCall(ns: WdlNamespaceWithWorkflow, name: String): TaskCall = ns.workflow.taskCalls.find(_.unqualifiedName == name) getOrElse {
     fail(s"Expecting call with name '$name'")

--- a/src/test/scala/wdl4s/WorkflowImportsSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowImportsSpec.scala
@@ -3,11 +3,10 @@ package wdl4s
 import better.files.File
 import org.scalatest.{FlatSpec, Matchers}
 
-
 class WorkflowImportsSpec extends FlatSpec with Matchers {
 
   def addAndGetFile(name: String, source: String): String = {
-    val tempFile = File.newTemporaryFile(s"${name}", ".wdl", Option(wdlDirectory)) write source
+    val tempFile = File.newTemporaryFile(s"$name", ".wdl", Option(wdlDirectory)) write source
     tempFile.name
   }
 
@@ -233,7 +232,10 @@ class WorkflowImportsSpec extends FlatSpec with Matchers {
 
   val wdlWithImports = imports + primaryWorkflow
 
-  val namespace = WdlNamespaceWithWorkflow.load(wdlWithImports, wdlDirectory).get
+  val namespace = {
+    val resolvers: Seq[ImportResolver] = Seq(WdlNamespace.directoryResolver(wdlDirectory), WdlNamespace.fileResolver)
+    WdlNamespaceWithWorkflow.load(wdlWithImports, resolvers).get
+  }
 
   "WDL file with imports" should "Have 1 task (remaining tasks are in separate namespaces)" in {
     namespace.tasks.size shouldEqual 1

--- a/src/test/scala/wdl4s/WorkflowSpec.scala
+++ b/src/test/scala/wdl4s/WorkflowSpec.scala
@@ -8,7 +8,7 @@ import wdl4s.parser.WdlParser.SyntaxError
 import wdl4s.types._
 import wdl4s.values._
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 class WorkflowSpec extends WordSpec with Matchers {
 
@@ -144,7 +144,8 @@ class WorkflowSpec extends WordSpec with Matchers {
     }
     
     def verifyOutputs(outputString: String, declarationExpectations: Seq[WorkflowOutputExpectation], evaluationExpectations: Map[String, WdlValue]) = {
-      val ns = WdlNamespaceWithWorkflow.load(wdl.replace("<<OUTPUTS>>", outputString), importResolver = (uri: String) => subWorkflow).get
+      val ns = WdlNamespaceWithWorkflow.load(
+        wdl.replace("<<OUTPUTS>>", outputString), Seq((uri: String) => subWorkflow)).get
       verifyOutputsForNamespace(ns, declarationExpectations, evaluationExpectations, outputResolverForWorkflow(ns.workflow))
     }
 
@@ -408,7 +409,7 @@ class WorkflowSpec extends WordSpec with Matchers {
         """.stripMargin
 
       a[SyntaxError] should be thrownBy {
-        WdlNamespaceWithWorkflow.load(wdl.replace("<<OUTPUTS>>", output), importResolver = (uri: String) => subWorkflow).get
+        WdlNamespaceWithWorkflow.load(wdl.replace("<<OUTPUTS>>", output), Seq((uri: String) => subWorkflow)).get
       }
     }
 
@@ -437,7 +438,7 @@ class WorkflowSpec extends WordSpec with Matchers {
         "t.o2" -> WdlString("o2")
       )
 
-      val ns = WdlNamespaceWithWorkflow.load(wdl).get
+      val ns = WdlNamespaceWithWorkflow.load(wdl, Seq.empty).get
 
       def outputResolver(call: GraphNode, index: Option[Int])= {
         call match {
@@ -483,7 +484,8 @@ class WorkflowSpec extends WordSpec with Matchers {
           |}
         """.stripMargin
       
-      val exception = the[SyntaxError] thrownBy WdlNamespaceWithWorkflow.load(parentWorkflow, importResolver = (uri: String) => subWorkflow).get
+      val exception = the[SyntaxError] thrownBy
+        WdlNamespaceWithWorkflow.load(parentWorkflow, Seq((uri: String) => subWorkflow)).get
       exception.getMessage shouldBe s"""Workflow sub_workflow is used as a sub workflow but has outputs declared with a deprecated syntax not compatible with sub workflows.
                                         |To use this workflow as a sub workflow please update the workflow outputs section to the latest WDL specification.
                                         |See https://github.com/broadinstitute/wdl/blob/develop/SPEC.md#outputs""".stripMargin

--- a/src/test/scala/wdl4s/expression/TypeEvaluatorSpec.scala
+++ b/src/test/scala/wdl4s/expression/TypeEvaluatorSpec.scala
@@ -10,7 +10,7 @@ import scala.util.{Failure, Success, Try}
 
 class TypeEvaluatorSpec extends FlatSpec with Matchers {
   val expr: String => WdlExpression = WdlExpression.fromString
-  val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.ThreeStep.wdlSource()).get
+  val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.ThreeStep.wdlSource(), Seq.empty).get
 
   def noLookup(String: String): WdlType = fail("No identifiers should be looked up in this test")
 
@@ -24,7 +24,7 @@ class TypeEvaluatorSpec extends FlatSpec with Matchers {
   def identifierEval(exprStr: String): WdlPrimitiveType = expr(exprStr).evaluateType(identifierLookup, new WdlStandardLibraryFunctionsType).asInstanceOf[Try[WdlPrimitiveType]].get
   def identifierEvalError(exprStr: String): Unit = {
     expr(exprStr).evaluateType(identifierLookup, new WdlStandardLibraryFunctionsType).asInstanceOf[Try[WdlPrimitive]] match {
-      case Failure(ex) => // Expected
+      case Failure(_) => // Expected
       case Success(badValue) => fail(s"Operation was supposed to fail, instead I got value: $badValue")
     }
   }

--- a/src/test/scala/wdl4s/types/WdlPairTypeSpec.scala
+++ b/src/test/scala/wdl4s/types/WdlPairTypeSpec.scala
@@ -97,6 +97,6 @@ class WdlPairTypeSpec extends FlatSpec with Matchers {
         |}
       """.stripMargin
     
-    noException should be thrownBy WdlNamespaceWithWorkflow.load(wdl)
+    noException should be thrownBy WdlNamespaceWithWorkflow.load(wdl, Seq.empty)
   }
 }


### PR DESCRIPTION
Updated calls to deprecated code.
Synced the README examples.
More info generated during scalatest.
Synced lenthall version with the one used in cromwell.
Also no longer auto-merging the changelog, as we couldn't quite get auto-merging to work with our flow, requiring further manual intervention anyway.