### PR TITLE
Various updates.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,4 +61,7 @@ libraryDependencies ++= Seq(
 // https://github.com/scala/pickling/issues/10
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-Xmax-classfile-name", "200")
 
+// http://stackoverflow.com/questions/31488335/scaladoc-2-11-6-fails-on-throws-tag-with-unable-to-find-any-member-to-link#31497874
+scalacOptions in (Compile, doc) ++= Seq("-no-link-warnings")
+
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDSI", "-h", "target/test-reports")

--- a/src/main/scala/wdl4s/Scope.scala
+++ b/src/main/scala/wdl4s/Scope.scala
@@ -182,7 +182,7 @@ trait Scope {
     * @param wdlFunctions Implementation of WDL functions for expression evaluation
     * @param shards For resolving specific shards of scatter blocks
     * @return String => WdlValue lookup function rooted at `scope`
-    * @throws VariableNotFoundException => If no errors occurred, but also `name` didn't resolve to any value
+    * @throws VariableNotFoundException If no errors occurred, but also `name` didn't resolve to any value
     * @throws VariableLookupException if anything else goes wrong in looking up a value for `name`
     */
   def lookupFunction(knownInputs: WorkflowCoercedInputs,
@@ -204,7 +204,7 @@ trait Scope {
           }
         case (Success(value: WdlArray), Some(shard)) =>
           Failure(new VariableLookupException(s"Scatter expression (${scatter.collection.toWdlString}) evaluated to an array of ${value.value.size} elements, but element $shard was requested."))
-        case (Success(value: WdlArray), None) =>
+        case (Success(_: WdlArray), None) =>
           Failure(ScatterIndexNotFound(s"Could not find the shard mapping to this scatter ${scatter.fullyQualifiedName}"))
         case (Success(value: WdlValue), _) =>
           Failure(new VariableLookupException(s"Expected scatter expression (${scatter.collection.toWdlString}) to evaluate to an Array.  Instead, got a $value"))

--- a/src/main/scala/wdl4s/values/WdlInteger.scala
+++ b/src/main/scala/wdl4s/values/WdlInteger.scala
@@ -5,7 +5,7 @@ import wdl4s.types.WdlIntegerType
 
 import scala.util.{Failure, Success, Try}
 
-case class WdlInteger(value: Integer) extends WdlPrimitive {
+case class WdlInteger(value: Int) extends WdlPrimitive {
   val wdlType = WdlIntegerType
 
   override def add(rhs: WdlValue): Try[WdlValue] = rhs match {

--- a/src/test/scala/wdl4s/values/WdlValueSpec.scala
+++ b/src/test/scala/wdl4s/values/WdlValueSpec.scala
@@ -1,9 +1,9 @@
 package wdl4s.values
 
-import wdl4s.WdlExpression
-import wdl4s.types.{WdlMapType, WdlStringType}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.types.{WdlArrayType, WdlMapType, WdlStringType}
+import wdl4s.{SampleWdl, WdlExpression, WdlNamespaceWithWorkflow}
 
 class WdlValueSpec extends FlatSpec with Matchers {
 
@@ -59,7 +59,7 @@ class WdlValueSpec extends FlatSpec with Matchers {
       // Test that this is a special conversion, and is not
       // expected to be equal after a round-trip conversion.
       fromRawString shouldNot be(wdlValue)
-      validateFloat(fromRawString.value) should be(right = true)
+      validateFloat(fromRawString.value) should be(true)
       fromRawString.wdlType should be(wdlType)
     }
   }
@@ -86,6 +86,118 @@ class WdlValueSpec extends FlatSpec with Matchers {
       fromRawString shouldNot be(wdlValue)
       fromRawString.toWdlString should be(wdlValue.toWdlString)
       fromRawString.wdlType should be(wdlType)
+    }
+  }
+
+  val testCall = {
+    val namespace = WdlNamespaceWithWorkflow.load(SampleWdl.ThreeStep.wdlSource(), Seq.empty).get
+    namespace.calls.find(_.unqualifiedName == "wc").get
+  }
+
+  val wdlValueMaxedElements = Table(
+    ("wdlValue", "maxedElements"),
+    (WdlBoolean.False, WdlBoolean.False),
+    (WdlFile("hello/world/path"), WdlFile("hello/world/path")),
+    (WdlFile("*.txt", isGlob = true), WdlFile("*.txt", isGlob = true)),
+    (WdlFloat(0.0), WdlFloat(0.0)),
+    (WdlInteger(0), WdlInteger(0)),
+    (WdlString(""), WdlString("")),
+    (WdlPair(WdlInteger(1), WdlInteger(2)), WdlPair(WdlInteger(1), WdlInteger(2))),
+    (WdlOptionalValue(WdlStringType, None), WdlOptionalValue(WdlStringType, None)),
+    (
+      WdlOptionalValue(WdlStringType, Option(WdlString("optional"))),
+      WdlOptionalValue(WdlStringType, Option(WdlString("optional")))
+    ),
+    (
+      WdlObject(Map("0" -> WdlString("zero"))),
+      WdlObject(Map("0" -> WdlString("zero")))
+    ),
+    (
+      WdlObject(Map(
+        "0" -> WdlString("zero"), "1" -> WdlString("one"), "2" -> WdlString("two"), "3" -> WdlString("three")
+      )),
+      WdlObject(Map(
+        "0" -> WdlString("zero"), "1" -> WdlString("one"), "2" -> WdlString("two")
+      ))
+    ),
+    (
+      WdlCallOutputsObject(testCall, Map("0" -> WdlString("zero"))),
+      WdlCallOutputsObject(testCall, Map("0" -> WdlString("zero")))
+    ),
+    (
+      WdlCallOutputsObject(testCall, Map(
+        "0" -> WdlString("zero"), "1" -> WdlString("one"), "2" -> WdlString("two"), "3" -> WdlString("three")
+      )),
+      WdlCallOutputsObject(testCall, Map(
+        "0" -> WdlString("zero"), "1" -> WdlString("one"), "2" -> WdlString("two")
+      ))
+    ),
+    (
+      WdlMap(WdlMapType(WdlStringType, WdlStringType), Map(WdlString("0") -> WdlString("zero"))),
+      WdlMap(WdlMapType(WdlStringType, WdlStringType), Map(WdlString("0") -> WdlString("zero")))
+    ),
+    (
+      WdlMap(WdlMapType(WdlStringType, WdlStringType), Map(
+        WdlString("0") -> WdlString("zero"),
+        WdlString("1") -> WdlString("one"),
+        WdlString("2") -> WdlString("two"),
+        WdlString("3") -> WdlString("three")
+      )),
+      WdlMap(WdlMapType(WdlStringType, WdlStringType), Map(
+        WdlString("0") -> WdlString("zero"),
+        WdlString("1") -> WdlString("one"),
+        WdlString("2") -> WdlString("two")
+      ))
+    ),
+    (
+      WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("0"))),
+      WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("0")))
+    ),
+    (
+      WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("0"), WdlString("1"), WdlString("2"), WdlString("3"))),
+      WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("0"), WdlString("1"), WdlString("2")))
+    ),
+    (
+      WdlArray(
+        WdlArrayType(WdlArrayType(WdlStringType)),
+        Seq(
+          WdlArray(WdlArrayType(WdlStringType), Seq(
+            WdlString("a0"), WdlString("a1"), WdlString("a2"), WdlString("a3")
+          )),
+          WdlArray(WdlArrayType(WdlStringType), Seq(
+            WdlString("b0"), WdlString("b1"), WdlString("b2"), WdlString("b3")
+          )),
+          WdlArray(WdlArrayType(WdlStringType), Seq(
+            WdlString("c0"), WdlString("c1"), WdlString("c2"), WdlString("c3")
+          )),
+          WdlArray(WdlArrayType(WdlStringType), Seq(
+            WdlString("d0"), WdlString("d1"), WdlString("d2"), WdlString("d3")
+          ))
+        )
+      ),
+      WdlArray(
+        WdlArrayType(WdlArrayType(WdlStringType)),
+        Seq(
+          WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("a0"), WdlString("a1"), WdlString("a2"))),
+          WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("b0"), WdlString("b1"), WdlString("b2"))),
+          WdlArray(WdlArrayType(WdlStringType), Seq(WdlString("c0"), WdlString("c1"), WdlString("c2")))
+        )
+      )
+    )
+  )
+
+  private def describe(wdlValue: WdlValue): String = {
+    wdlValue match {
+      case WdlCallOutputsObject(call, outputs) =>
+        s"WdlCallOutputsObject(${call.unqualifiedName}, ${outputs.mapValues(_.toWdlString)})"
+      case _ => wdlValue.toWdlString
+    }
+  }
+
+  forAll(wdlValueMaxedElements) { (wdlValue, expected) =>
+    it should s"take max elements for ${describe(wdlValue)}" in {
+      val actual = WdlValue.takeMaxElements(wdlValue, 3)
+      actual should be(expected)
     }
   }
 }


### PR DESCRIPTION
Switched `WdlInteger` value from java reference to scala value.
Slightly better error messages when trying to coerce `Array[Int]?` to `Array[Int?]`, or vice versa.
Cleaned up scaladoc warnings.