### PR TITLE
Nicer call input/output validation messages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ crossScalaVersions := Seq("2.11.8", "2.12.1")
 
 lazy val versionSettings = Seq(
   // Upcoming release, or current if we're on the master branch
-  git.baseVersion := "0.11",
+  git.baseVersion := "0.12",
 
   // Shorten the git commit hash
   git.gitHeadCommit := git.gitHeadCommit.value map { _.take(7) },

--- a/src/main/scala/wdl4s/Workflow.scala
+++ b/src/main/scala/wdl4s/Workflow.scala
@@ -163,7 +163,7 @@ case class Workflow(unqualifiedName: String,
       namespace.resolveCallOrOutputOrDeclaration(outputFqn) match {
         case Some(call: Call) if output.wildcard && calls.contains(call) => toWorkflowOutputs(call)
         case Some(declaration: DeclarationInterface) if descendants.contains(declaration) => toWorkflowOutputs(declaration)
-        case e => throw new SyntaxError(wdlSyntaxErrorFormatter.memberAccessReferencesBadCallOutput(output.ast))
+        case e => throw new SyntaxError(wdlSyntaxErrorFormatter.badOldStyleWorkflowOutput(output.ast))
       }
     }
   }


### PR DESCRIPTION
New format for "that call doesn't have that output":
```
Unable to load namespace from workflow: ERROR: Call output not found: Call 'bar' doesn't have an output 'b' (line 4, col 47).

	call baz as bad_output_name { input: b = bar.b }
                                              ^

Options:
 - Add the output 'b' to ' bar':
 - Modify the member access (on line 4) to use an existing output (current outputs of 'bar': 'a')
```

New format for "that call doesn't want that input":
```
Unable to load namespace from workflow: ERROR: Call supplied an unexpected input: The 'baz' task doesn't have an input called 'a':

	call baz as bad_input_name { input: a = bar.a }
                                     ^

Options:
 - Add the input 'a' to the 'baz' task (defined on line 21).
 - Remove 'a = ...' from bad_input_name's inputs (on line 6).
```