### PR TITLE
Allow Map to Array coercion

### DIFF
--- a/src/main/scala/wdl4s/Scope.scala
+++ b/src/main/scala/wdl4s/Scope.scala
@@ -3,7 +3,8 @@ package wdl4s
 import wdl4s.exception.{ScatterIndexNotFound, VariableLookupException, VariableNotFoundException}
 import wdl4s.expression.WdlFunctions
 import wdl4s.parser.WdlParser.Ast
-import wdl4s.values.{WdlArray, WdlValue}
+import wdl4s.values.WdlArray.WdlArrayLike
+import wdl4s.values.WdlValue
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -197,14 +198,14 @@ trait Scope {
       val scatterShard = shards.get(scatter)
 
       (evaluatedCollection, scatterShard) match {
-        case (Success(value: WdlArray), Some(shard)) if 0 <= shard && shard < value.value.size =>
-          value.value.lift(shard) match {
+        case (Success(WdlArrayLike(array)), Some(shard)) if 0 <= shard && shard < array.value.size =>
+          array.value.lift(shard) match {
             case Some(v) => Success(v)
-            case None => Failure(new VariableLookupException(s"Could not find value for shard index $shard in scatter collection $value"))
+            case None => Failure(new VariableLookupException(s"Could not find value for shard index $shard in scatter collection $array"))
           }
-        case (Success(value: WdlArray), Some(shard)) =>
-          Failure(new VariableLookupException(s"Scatter expression (${scatter.collection.toWdlString}) evaluated to an array of ${value.value.size} elements, but element $shard was requested."))
-        case (Success(_: WdlArray), None) =>
+        case (Success(WdlArrayLike(array)), Some(shard)) =>
+          Failure(new VariableLookupException(s"Scatter expression (${scatter.collection.toWdlString}) evaluated to an array of ${array.value.size} elements, but element $shard was requested."))
+        case (Success(_: WdlArrayLike), None) =>
           Failure(ScatterIndexNotFound(s"Could not find the shard mapping to this scatter ${scatter.fullyQualifiedName}"))
         case (Success(value: WdlValue), _) =>
           Failure(new VariableLookupException(s"Expected scatter expression (${scatter.collection.toWdlString}) to evaluate to an Array.  Instead, got a $value"))

--- a/src/main/scala/wdl4s/WdlNamespace.scala
+++ b/src/main/scala/wdl4s/WdlNamespace.scala
@@ -513,6 +513,8 @@ object WdlNamespace {
             s.collection.evaluateType(lookupType(s), new WdlStandardLibraryFunctionsType) map {
               case WdlArrayType(WdlObjectType) => None
               case WdlArrayType(_: WdlPairType) if memberAccess.rhs == "left" || memberAccess.rhs == "right" => None
+              // Maps get coerced into arrays of pairs, so this is also ok:
+              case _: WdlMapType if memberAccess.rhs == "left" || memberAccess.rhs == "right" => None
               case _ => Option(new SyntaxError(wdlSyntaxErrorFormatter.variableIsNotAnObject(memberAccessAst)))
             } getOrElse None
           case Some(d: Declaration) => d.wdlType match {

--- a/src/main/scala/wdl4s/values/WdlMap.scala
+++ b/src/main/scala/wdl4s/values/WdlMap.scala
@@ -2,8 +2,9 @@ package wdl4s.values
 
 import lenthall.util.TryUtil
 import wdl4s.TsvSerializable
-import wdl4s.types.{WdlAnyType, WdlMapType, WdlPrimitiveType, WdlType}
+import wdl4s.types._
 import wdl4s.util.FileUtil
+import wdl4s.values.WdlArray.WdlArrayLike
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -41,7 +42,7 @@ object WdlMap {
   }
 }
 
-case class WdlMap(wdlType: WdlMapType, value: Map[WdlValue, WdlValue]) extends WdlValue with TsvSerializable {
+case class WdlMap(wdlType: WdlMapType, value: Map[WdlValue, WdlValue]) extends WdlValue with WdlArrayLike with TsvSerializable {
   val typesUsedInKey = value.map { case (k,v) => k.wdlType }.toSet
 
   if (typesUsedInKey.size == 1 && typesUsedInKey.head != wdlType.keyType)
@@ -83,4 +84,8 @@ case class WdlMap(wdlType: WdlMapType, value: Map[WdlValue, WdlValue]) extends W
     }
     collected.flatten.toSeq
   }
+
+  // For WdlArrayLike:
+  override lazy val arrayType: WdlArrayType = WdlArrayType(WdlPairType(wdlType.keyType, wdlType.valueType))
+  override lazy val asArray: WdlArray = WdlArray(arrayType, value.toSeq map { case (k, v) => WdlPair(k, v) })
 }

--- a/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
+++ b/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
@@ -1,6 +1,6 @@
 package wdl4s.types
 
-import wdl4s.values.{WdlArray, WdlInteger, WdlOptionalValue, WdlString, WdlValue}
+import wdl4s.values.{WdlArray, WdlInteger, WdlMap, WdlOptionalValue, WdlPair, WdlString, WdlValue}
 import wdl4s.parser.WdlParser.SyntaxError
 import org.scalatest.{FlatSpec, Matchers}
 import spray.json.{JsArray, JsNumber}
@@ -126,6 +126,13 @@ class WdlArrayTypeSpec extends FlatSpec with Matchers  {
     } catch {
       case _: UnsupportedOperationException => // expected
     }
+  }
+  it should "be able to coerce a map into an array of pairs" in {
+    val map = WdlMap(WdlMapType(WdlIntegerType, WdlStringType), Map(WdlInteger(1) -> WdlString("one")))
+    val arrayOfPairsType = WdlArrayType(WdlPairType(WdlIntegerType, WdlStringType))
+    arrayOfPairsType.isCoerceableFrom(map.wdlType) should be(true)
+    arrayOfPairsType.coerceRawValue(map) should be(Success(WdlArray(WdlArrayType(WdlPairType(WdlIntegerType, WdlStringType)), List(WdlPair(WdlInteger(1), WdlString("one"))))))
+
   }
 
   List(WdlStringType, WdlArrayType(WdlIntegerType), WdlPairType(WdlIntegerType, WdlPairType(WdlIntegerType, WdlIntegerType)), WdlOptionalType(WdlStringType)) foreach { desiredMemberType =>


### PR DESCRIPTION
Allows, e.g.:
```
task print {
	Int id
	String value
	command {
		echo ${id}: ${value}
	}
	output {
		String out = read_string(stdout())
	}
}


workflow foo {
	Map[Int, String] map  = {
		1: "one",
		2: "two",
		3: "three"
	}

	Array[Pair[Int, String]] listOfPairs = map
	scatter (pair in listOfPairs) {
	  call print {input: id = pair.left, value = pair.right}
	}
}
```