### PR TITLE
Add trailing newline in tsv serialization

### DIFF
--- a/src/main/scala/wdl4s/WdlExpression.scala
+++ b/src/main/scala/wdl4s/WdlExpression.scala
@@ -1,6 +1,5 @@
 package wdl4s
 
-import lenthall.exception.ThrowableAggregation
 import wdl4s.AstTools.EnhancedAstNode
 import wdl4s.WdlExpression._
 import wdl4s.expression._
@@ -12,7 +11,7 @@ import wdl4s.values._
 
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
-import scala.util.{Failure, Try}
+import scala.util.Try
 
 class WdlExpressionException(message: String = null, cause: Throwable = null) extends RuntimeException(message, cause)
 

--- a/src/main/scala/wdl4s/util/FileUtil.scala
+++ b/src/main/scala/wdl4s/util/FileUtil.scala
@@ -4,7 +4,7 @@ import scala.util.{Failure, Success, Try}
 
 object FileUtil {
   def parseTsv(tsv: String): Try[Array[Array[String]]] = {
-    val table = tsv.split("\n").map(_.split("\t"))
+    val table = tsv.trim.split("\n").map(_.split("\t"))
     table.map(_.length).toSet match {
       case s if s.size > 1 => Failure(new UnsupportedOperationException("TSV is not uniform"))
       case _ => Success(table)

--- a/src/main/scala/wdl4s/values/WdlArray.scala
+++ b/src/main/scala/wdl4s/values/WdlArray.scala
@@ -58,12 +58,13 @@ sealed abstract case class WdlArray(wdlType: WdlArrayType, value: Seq[WdlValue])
 
   def tsvSerialize: Try[String] = {
     wdlType.memberType match {
-      case t: WdlPrimitiveType => Success(value.map(_.valueString).mkString("\n"))
+      case t: WdlPrimitiveType => Success(value.map(_.valueString).mkString(start = "", sep = "\n", end = "\n"))
       case WdlObjectType => WdlObject.tsvSerializeArray(value map { _.asInstanceOf[WdlObject] })
       case WdlArrayType(t: WdlPrimitiveType) =>
         val tsvString = value.collect({ case a: WdlArray => a }) map { a =>
-          a.value.collect({ case p: WdlPrimitive => p }).map(_.valueString).mkString("\t")
-        } mkString "\n"
+          a.value.collect({ case p: WdlPrimitive => p.valueString }).mkString(start = "", sep = "\t", end = "\n")
+        } mkString
+
         Success(tsvString)
       case _ => Failure(new UnsupportedOperationException(s"Cannot TSV serialize a ${this.wdlType.toWdlString} (valid types are Array[Primitive], Array[Array[Primitive]], or Array[Object])"))
     }

--- a/src/main/scala/wdl4s/values/WdlObject.scala
+++ b/src/main/scala/wdl4s/values/WdlObject.scala
@@ -2,7 +2,7 @@ package wdl4s.values
 
 import wdl4s.types._
 import wdl4s.util.FileUtil
-import wdl4s.{Call, TaskCall, TsvSerializable}
+import wdl4s.{Call, TsvSerializable}
 
 import scala.util.{Failure, Success, Try}
 
@@ -53,7 +53,7 @@ object WdlObject {
         val attributesLine = attributes.mkString("\t")
         val valuesLines = objects map { obj =>
           attributes map { obj.value(_).valueString } mkString "\t"
-        } mkString "\n"
+        } mkString(start = "", sep = "\n", end = "\n")
 
         Success(s"$attributesLine\n$valuesLines")
       case _ => Failure(new UnsupportedOperationException("Could not serialize array: Objects in the array have different attributes."))
@@ -72,13 +72,13 @@ case class WdlObject(value: Map[String, WdlValue]) extends WdlValue with WdlObje
   lazy val orderedValues = orderedAttributes map { value(_) }
 
   def tsvSerialize: Try[String] = Try {
-    val keysLine = orderedAttributes.mkString("\t")
+    val keysLine = orderedAttributes.mkString(start = "", sep = "\t", end = "\n")
     val values = orderedValues map {
       case v if v.isInstanceOf[WdlPrimitive] => v.valueString
       case _ => throw new UnsupportedOperationException("Can only TSV serialize an Object with Primitive values.")
     }
 
-    s"$keysLine\n${values.mkString("\t")}"
+    keysLine + values.mkString(start = "", sep = "\t", end = "\n")
   }
 }
 

--- a/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
+++ b/src/test/scala/wdl4s/types/WdlArrayTypeSpec.scala
@@ -23,7 +23,7 @@ class WdlArrayTypeSpec extends FlatSpec with Matchers  {
         WdlArray(WdlArrayType(WdlStringType), Seq("c", "d").map(WdlString))
       )
     )
-    nestedArray.tsvSerialize shouldEqual Success("a\tb\nc\td")
+    nestedArray.tsvSerialize shouldEqual Success("a\tb\nc\td\n")
   }
   it should "fail to TSV serialize an Array[Array[Array[String]]]" in {
     try {

--- a/src/test/scala/wdl4s/values/WdlObjectSpec.scala
+++ b/src/test/scala/wdl4s/values/WdlObjectSpec.scala
@@ -3,76 +3,100 @@ package wdl4s.values
 import wdl4s.types.{WdlArrayType, WdlObjectType}
 import org.scalatest.{FlatSpec, Matchers, TryValues}
 
+object WdlObjectSpec {
+  implicit class Trimmer(val string: String) extends AnyVal {
+    // Return both the original version of the string as well as a version trimmed of a newline.
+    def withTrimmed: List[String] = List(string, string.trim)
+  }
+}
+
 class WdlObjectSpec extends FlatSpec with Matchers with TryValues {
-  val correctTSV = "one\ttwo\tthree\tfour\none\tfour\tnine\tsixteen"
+  import WdlObjectSpec._
+  val correctTSV = "one\ttwo\tthree\tfour\none\tfour\tnine\tsixteen\n"
   val emptyTSV = ""
-  val oneRowTSV = "one\ttwo\tthree\tfour"
-  val nonHomogeneousTS = "onet\ttwo\tthree\none\ttwo"
-  val arrayTSV = correctTSV + "\none\teight\ttwentyseven\tsixtyfour"
+  val oneRowTSV = "one\ttwo\tthree\tfour\n"
+  val nonHomogeneousTSV = "one\ttwo\tthree\none\ttwo\n"
+  val arrayTSV = correctTSV + "one\teight\ttwentyseven\tsixtyfour\n"
 
   it should "read an Object from a correct TSV file" in {
-    val parsed = WdlObject.fromTsv(correctTSV)
-    parsed should be a 'success
-    val array: Array[WdlObject] = parsed.success.value
-    array should have size 1
+    // Test both a version of the TSV with and without a trailing newline.
+    correctTSV.withTrimmed foreach { tsv =>
+      val parsed = WdlObject.fromTsv(tsv)
+      parsed should be a 'success
+      val array: Array[WdlObject] = parsed.success.value
+      array should have size 1
 
-    //Attributes
-    array.head.value should contain key "one"
-    array.head.value should contain key "two"
-    array.head.value should contain key "three"
-    array.head.value should contain key "four"
+      //Attributes
+      array.head.value should contain key "one"
+      array.head.value should contain key "two"
+      array.head.value should contain key "three"
+      array.head.value should contain key "four"
 
-    //Values
-    array.head.value.get("one") shouldBe Some(WdlString("one"))
-    array.head.value.get("two") shouldBe Some(WdlString("four"))
-    array.head.value.get("three") shouldBe Some(WdlString("nine"))
-    array.head.value.get("four") shouldBe Some(WdlString("sixteen"))
+      //Values
+      array.head.value.get("one") shouldBe Some(WdlString("one"))
+      array.head.value.get("two") shouldBe Some(WdlString("four"))
+      array.head.value.get("three") shouldBe Some(WdlString("nine"))
+      array.head.value.get("four") shouldBe Some(WdlString("sixteen"))
+    }
   }
 
   it should "NOT read from a TSV file with less than 2 rows" in {
-    WdlObject.fromTsv(emptyTSV) should be a 'failure
-    WdlObject.fromTsv(oneRowTSV) should be a 'failure
+    for {
+      tsv <- List(emptyTSV, oneRowTSV)
+      t <- tsv.withTrimmed
+      _ = WdlObject.fromTsv(t) should be a 'failure
+    } yield ()
   }
 
   it should "NOT read from a non homogeneous TSV file" in {
-    WdlObject.fromTsv(nonHomogeneousTS) should be a 'failure
+    nonHomogeneousTSV.withTrimmed foreach {
+      WdlObject.fromTsv(_) should be a 'failure
+    }
   }
 
   it should "serialize to TSV" in {
-    val obj = WdlObject.fromTsv(correctTSV).get.head
-    val serialized = obj.tsvSerialize
-    serialized should be a 'success
-    serialized.success.value shouldEqual correctTSV
+    correctTSV.withTrimmed foreach { tsv =>
+      val obj = WdlObject.fromTsv(tsv).get.head
+      val serialized = obj.tsvSerialize
+      serialized should be a 'success
+      serialized.success.value shouldEqual correctTSV
+    }
   }
 
   it should "read a WdlArray[WdlObject] from a correct TSV file" in {
-    val parsed = WdlObject.fromTsv(arrayTSV)
-    parsed should be a 'success
-    val array: Array[WdlObject] = parsed.success.value
-    array should have size 2
+    List(arrayTSV, arrayTSV.trim) foreach { tsv =>
+      val parsed = WdlObject.fromTsv(tsv)
+      parsed should be a 'success
+      val array: Array[WdlObject] = parsed.success.value
+      array should have size 2
 
-    //Attributes
-    array foreach { _.value should contain key "one" }
-    array foreach { _.value should contain key "two" }
-    array foreach { _.value should contain key "three" }
-    array foreach { _.value should contain key "four" }
+      //Attributes
+      array foreach { a =>
+        a.value should contain key "one"
+        a.value should contain key "two"
+        a.value should contain key "three"
+        a.value should contain key "four"
+      }
 
-    //Values
-    array.head.value.get("one") shouldBe Some(WdlString("one"))
-    array.head.value.get("two") shouldBe Some(WdlString("four"))
-    array.head.value.get("three") shouldBe Some(WdlString("nine"))
-    array.head.value.get("four") shouldBe Some(WdlString("sixteen"))
+      //Values
+      array.head.value.get("one") shouldBe Some(WdlString("one"))
+      array.head.value.get("two") shouldBe Some(WdlString("four"))
+      array.head.value.get("three") shouldBe Some(WdlString("nine"))
+      array.head.value.get("four") shouldBe Some(WdlString("sixteen"))
 
-    array(1).value.get("one") shouldBe Some(WdlString("one"))
-    array(1).value.get("two") shouldBe Some(WdlString("eight"))
-    array(1).value.get("three") shouldBe Some(WdlString("twentyseven"))
-    array(1).value.get("four") shouldBe Some(WdlString("sixtyfour"))
+      array(1).value.get("one") shouldBe Some(WdlString("one"))
+      array(1).value.get("two") shouldBe Some(WdlString("eight"))
+      array(1).value.get("three") shouldBe Some(WdlString("twentyseven"))
+      array(1).value.get("four") shouldBe Some(WdlString("sixtyfour"))
+    }
   }
 
   it should "serialize a WdlArray[WdlObject] to TSV" in {
-    val array = WdlArray(WdlArrayType(WdlObjectType), WdlObject.fromTsv(arrayTSV).get)
-    val serialized = array.tsvSerialize
-    serialized should be a 'success
-    serialized.success.value shouldEqual arrayTSV
+    List(arrayTSV, arrayTSV.trim) foreach { tsv =>
+      val array = WdlArray(WdlArrayType(WdlObjectType), WdlObject.fromTsv(tsv).get)
+      val serialized = array.tsvSerialize
+      serialized should be a 'success
+      serialized.success.value shouldEqual arrayTSV
+    }
   }
 }


### PR DESCRIPTION
Changes to add trailing newlines in TSV serialization, for the benefit of write_lines and other functions.  There's a corresponding Centaur branch which allows for the removal of some [hackery](https://github.com/broadinstitute/centaur/commit/c770edbd2c98ba12d46051164232ae8c5e60012b).