### PR TITLE
Un-micropatch. It was right the first time.

### DIFF
--- a/wom/src/main/scala/wdl4s/wdl/expression/WdlStandardLibraryFunctions.scala
+++ b/wom/src/main/scala/wdl4s/wdl/expression/WdlStandardLibraryFunctions.scala
@@ -350,7 +350,7 @@ class WdlStandardLibraryFunctionsType extends WdlFunctions[WdlType] {
   def glob(params: Seq[Try[WdlType]]): Try[WdlType] = Success(WdlArrayType(WdlFileType))
   def size(params: Seq[Try[WdlType]]): Try[WdlType] = {
     def isGoodFirstSizeParam(wdlType: WdlType): Boolean = wdlType match {
-      case WdlFileType => true
+      case f if WdlFileType.isCoerceableFrom(f) => true
       case WdlOptionalType(o) => isGoodFirstSizeParam(o)
       case _ => false
     }


### PR DESCRIPTION
Turns out we do want to have "things that can coerce to file" so that we can do `Float f = size("myoutput.txt")`