### PR TITLE
FileEvaluator handles: two parameter functions and function calls

### DIFF
--- a/wom/src/main/scala/wdl4s/wdl/WdlExpression.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlExpression.scala
@@ -33,11 +33,10 @@ object WdlExpression {
     def isMapLiteral: Boolean = ast.getName == "MapLiteral"
     def isObjectLiteral: Boolean = ast.getName == "ObjectLiteral"
     def isArrayOrMapLookup: Boolean = ast.getName == "ArrayOrMapLookup"
-    def params = ast.getAttribute("params").asInstanceOf[AstList].asScala.toVector
+    def params: Vector[AstNode] = Option(ast.getAttribute("params")).map(_.asInstanceOf[AstList].asScala.toVector).getOrElse(Vector.empty)
     def name = ast.getAttribute("name").asInstanceOf[Terminal].getSourceString
-    def isFunctionCallWithOneParameter = ast.isFunctionCall && ast.params.size == 1
-    def isFunctionCallWithOneFileParameter = isFunctionCallWithOneParameter && WdlFunctionsWithSingleFileParameter.contains(ast.functionName)
-    def isGlobFunctionCall = isFunctionCallWithOneParameter && "glob".equals(ast.functionName)
+    def isFunctionCallWithFirstParameterBeingFile = ast.isFunctionCall && ast.params.nonEmpty && WdlFunctionsWithFirstParameterBeingFile.contains(ast.functionName)
+    def isGlobFunctionCall = ast.isFunctionCall && ast.params.size == 1 && "glob".equals(ast.functionName)
   }
 
   implicit class AstNodeForExpressions(val astNode: AstNode) extends AnyVal {
@@ -53,7 +52,7 @@ object WdlExpression {
           rhs.containsFunctionCalls
         case _ => false
       }
-    
+
     def isTerminal: Boolean = astNode.isInstanceOf[Terminal]
   }
 
@@ -70,7 +69,7 @@ object WdlExpression {
 
   val UnaryOperators = Set("LogicalNot", "UnaryPlus", "UnaryNegation")
 
-  val WdlFunctionsWithSingleFileParameter: Seq[String] = Seq(
+  val WdlFunctionsWithFirstParameterBeingFile: Seq[String] = Seq(
     "read_int",
     "read_string",
     "read_float",

--- a/wom/src/test/scala/wdl4s/wdl/expression/FileEvaluatorSpec.scala
+++ b/wom/src/test/scala/wdl4s/wdl/expression/FileEvaluatorSpec.scala
@@ -48,7 +48,12 @@ class FileEvaluatorSpec extends FlatSpec with Matchers {
     (""" if read_int("i.txt") == 10 then "a.txt" else "b.txt" """, Seq(WdlSingleFile("a.txt"), WdlSingleFile("b.txt"), WdlSingleFile("i.txt")), WdlFileType),
     (""" if "a" == "b" then "a.txt" else "b.txt" """, Seq(WdlSingleFile("b.txt")), WdlFileType),
     (""" if b then read_string("t") else "nope" """, Seq(WdlSingleFile("t")), WdlStringType),
-    (""" read_string(basename(fileInput, ".txt") + ".bam") """, Seq(WdlSingleFile("input.bam")), WdlStringType)
+    (""" read_string(basename(fileInput, ".txt") + ".bam") """, Seq(WdlSingleFile("input.bam")), WdlStringType),
+    (""" size("foo.txt") """, Seq(WdlSingleFile("foo.txt")), WdlFloatType),
+    (""" round(size("foo.txt")) """, Seq(WdlSingleFile("foo.txt")), WdlIntegerType),
+    (""" size("foo.txt", "GB") """, Seq(WdlSingleFile("foo.txt")), WdlIntegerType),
+    (""" round(size("foo.txt", "GB")) """, Seq(WdlSingleFile("foo.txt")), WdlIntegerType)
+
   )
 
   val lookupFunction = Map(
@@ -58,9 +63,9 @@ class FileEvaluatorSpec extends FlatSpec with Matchers {
     "mapToFileName" -> WdlMap(Map(WdlString("Chris") -> WdlString("sommatStupid.bam")))
   )
 
-  forAll (expressions) { (expression, files, wdlType) =>
-    it should s"evaluate $expression (coerced to: $wdlType) => $files" in {
-      WdlExpression.fromString(expression).evaluateFiles(lookupFunction, PureStandardLibraryFunctions, wdlType).get.toSet should be(files.toSet)
+  forAll (expressions) { (expression, files, anticipatedType) =>
+    it should s"evaluate $expression (coerced to: $anticipatedType) => $files" in {
+      WdlExpression.fromString(expression).evaluateFiles(lookupFunction, PureStandardLibraryFunctions, anticipatedType).get.toSet should be(files.toSet)
     }
   }
 }


### PR DESCRIPTION
To enable output blocks like:
```
output {
  # Function call in a function call:
  Int x = round(size("myfile.txt"))
  # Two parameter function call:
  Float y = size("myFile.txt", "GB")
}
```