### PR TITLE
WOM ExpressionNodes

### DIFF
--- a/wom/src/main/scala/wdl4s/wdl/TaskOutput.scala
+++ b/wom/src/main/scala/wdl4s/wdl/TaskOutput.scala
@@ -14,7 +14,7 @@ object TaskOutput {
     TaskOutput(name, wdlType, expression, ast, parent)
   }
   
-  def buildWomOutputDefinition(taskOutput: TaskOutput) = OutputDefinition(taskOutput.unqualifiedName, taskOutput.wdlType, PlaceholderWomExpression(taskOutput.wdlType))
+  def buildWomOutputDefinition(taskOutput: TaskOutput) = OutputDefinition(taskOutput.unqualifiedName, taskOutput.wdlType, PlaceholderWomExpression(Set.empty, taskOutput.wdlType))
 }
 
 final case class TaskOutput(unqualifiedName: String, wdlType: WdlType, requiredExpression: WdlExpression, ast: Ast, override val parent: Option[Scope]) extends Output {

--- a/wom/src/main/scala/wdl4s/wdl/WdlTask.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlTask.scala
@@ -223,7 +223,7 @@ case class WdlTask(name: String,
 
   private def buildWomDeclarations: List[(String, WomExpression)] = declarations.toList collect {
     case d if d.expression.nonEmpty =>
-      d.unqualifiedName -> PlaceholderWomExpression(d.wdlType)
+      d.unqualifiedName -> PlaceholderWomExpression(Set.empty, d.wdlType)
   }
 
   private def buildWomInputs: Set[Callable.InputDefinition] = declarations collect {
@@ -232,6 +232,6 @@ case class WdlTask(name: String,
     case d if d.expression.isEmpty && d.wdlType.isInstanceOf[WdlOptionalType] =>
       OptionalInputDefinition(d.unqualifiedName, d.wdlType.asInstanceOf[WdlOptionalType])
     case d if d.expression.nonEmpty && d.wdlType.isInstanceOf[WdlOptionalType] =>
-      OptionalInputDefinitionWithDefault(d.unqualifiedName, d.wdlType.asInstanceOf[WdlOptionalType], PlaceholderWomExpression(d.wdlType))
+      OptionalInputDefinitionWithDefault(d.unqualifiedName, d.wdlType.asInstanceOf[WdlOptionalType], PlaceholderWomExpression(Set.empty, d.wdlType))
   } toSet
 }

--- a/wom/src/main/scala/wdl4s/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wdl4s/wom/expression/WomExpression.scala
@@ -1,25 +1,24 @@
 package wdl4s.wom.expression
 
+import cats.data.Validated.Valid
+import lenthall.validation.ErrorOr.ErrorOr
 import wdl4s.wdl.types.WdlType
 import wdl4s.wdl.values.WdlValue
 
 import scala.concurrent.Future
 
 trait WomExpression {
-  def inputs: Set[NamedExpressionInput]
-  def evaluate(variableValues: ExpressionInputs, ioFunctionSet: IoFunctionSet): WdlValue
-  def womType: WdlType
+  def inputs: Set[String]
+  def evaluateValue(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue]
+  def evaluateType(inputTypes: Map[String, WdlType]): ErrorOr[WdlType]
 }
 
-final case class PlaceholderWomExpression(womType: WdlType) extends WomExpression {
-  override def inputs: Set[NamedExpressionInput] = ???
-  override def evaluate(variableValues: ExpressionInputs, ioFunctionSet: IoFunctionSet): WdlValue = ???
+final case class PlaceholderWomExpression(inputs: Set[String], fixedWomType: WdlType) extends WomExpression {
+  override def evaluateValue(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue] = ???
+  override def evaluateType(inputTypes: Map[String, WdlType]): ErrorOr[WdlType] = Valid(fixedWomType)
 }
 
-final case class NamedExpressionInput(name: String, womType: WdlType)
-
-final case class ExpressionInputs(values: Map[NamedExpressionInput, WdlValue]) extends AnyVal
-
+// TODO: Flesh this out (https://github.com/broadinstitute/cromwell/issues/2521)
 trait IoFunctionSet {
   def read_file(path: String): Future[String]
   def write_file(path: String, content: String): Future[Unit]

--- a/wom/src/main/scala/wdl4s/wom/graph/ExpressionNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/ExpressionNode.scala
@@ -1,0 +1,20 @@
+package wdl4s.wom.graph
+
+
+import lenthall.validation.ErrorOr.ErrorOr
+import wdl4s.wom.expression.WomExpression
+import wdl4s.wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
+
+case class ExpressionNode private(name: String, instantiatedExpression: InstantiatedExpression) extends GraphNode {
+
+  val womType = instantiatedExpression.womReturnType
+  val singleExpressionOutputPort = GraphNodeOutputPort(name, womType, this)
+
+  override val inputPorts = instantiatedExpression.inputPorts
+  override val outputPorts: Set[GraphNodePort.OutputPort] = Set(singleExpressionOutputPort)
+}
+
+object ExpressionNode {
+  def linkWithInputs(name: String, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionNode] =
+    InstantiatedExpression.instantiateExpressionForNode(ExpressionNode.apply)(name, expression, inputMapping)
+}

--- a/wom/src/main/scala/wdl4s/wom/graph/InstantiatedExpression.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/InstantiatedExpression.scala
@@ -1,0 +1,44 @@
+package wdl4s.wom.graph
+
+import cats.instances.list._
+import cats.syntax.traverse._
+import cats.syntax.validated._
+import cats.data.Validated.Valid
+import lenthall.validation.ErrorOr.ErrorOr
+import wdl4s.wdl.types.WdlType
+import wdl4s.wom.expression.WomExpression
+import wdl4s.wom.graph.GraphNodePort.{ConnectedInputPort, InputPort, OutputPort}
+
+class InstantiatedExpression private(val expression: WomExpression, val womReturnType: WdlType, val inputMapping: Map[String, InputPort]) {
+  val inputPorts = inputMapping.values.toSet
+}
+
+object InstantiatedExpression {
+
+  private[graph] def instantiateExpressionForNode[ExpressionBasedNode <: GraphNode](nodeConstructor: (String, InstantiatedExpression) => ExpressionBasedNode)(name: String, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionBasedNode] = {
+    val graphNodeSetter = new GraphNode.GraphNodeSetter()
+
+    for {
+      linkedInputs <- InstantiatedExpression.linkWithInputs(graphNodeSetter, expression, inputMapping)
+      expressionNode = nodeConstructor(name, linkedInputs)
+      _ = graphNodeSetter._graphNode = expressionNode
+    } yield expressionNode
+  }
+
+  def linkWithInputs(graphNodeSetter: GraphNode.GraphNodeSetter, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[InstantiatedExpression] = {
+    def linkInput(input: String): ErrorOr[(String, InputPort)] = if (inputMapping.contains(input)) {
+      val upstreamPort = inputMapping(input)
+      Valid((input, ConnectedInputPort(input, upstreamPort.womType, upstreamPort, graphNodeSetter.get)))
+    } else {
+      s"Expression cannot be connected without the input $input.".invalidNel
+    }
+
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    for {
+      linkedInputList <- expression.inputs.toList traverse linkInput
+      linkedInputs = linkedInputList.toMap
+      inputTypes = linkedInputs map { case (k, v) => k -> v.womType }
+      evaluatedType <- expression.evaluateType(inputTypes)
+    } yield new InstantiatedExpression(expression, evaluatedType, linkedInputs)
+  }
+}

--- a/wom/src/test/scala/wdl4s/wom/graph/ExpressionNodeSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/ExpressionNodeSpec.scala
@@ -1,0 +1,62 @@
+package wdl4s.wom.graph
+
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.wdl.types.WdlIntegerType
+import wdl4s.wom.expression._
+
+class ExpressionNodeSpec extends FlatSpec with Matchers {
+
+  behavior of "ExpressionBasedGraphOutputNode"
+
+  /**
+    * Roughly equivalent to the WDL (except that the expression could be anything):
+    *
+    * workflow foo {
+    *   Int i
+    *   Int j
+    *   Int x = i + j
+    *
+    *   output {
+    *     Int x_out = x
+    *   }
+    * }
+    *
+    */
+  it should "construct an ExpressionNode if inputs are available" in {
+    // Two inputs:
+    val iInputNode = RequiredGraphInputNode("i", WdlIntegerType)
+    val jInputNode = RequiredGraphInputNode("j", WdlIntegerType)
+
+    // Declare an expression that needs both an "i" and a "j":
+    val ijExpression = PlaceholderWomExpression(Set("i", "j"), WdlIntegerType)
+
+    // Declare the expression node using both i and j:
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    val graph = for {
+      xDeclarationNode <- ExpressionNode.linkWithInputs("x", ijExpression, Map("i" -> iInputNode.singleOutputPort, "j" -> jInputNode.singleOutputPort))
+      xOutputNode = PortBasedGraphOutputNode("x_out", WdlIntegerType, xDeclarationNode.singleExpressionOutputPort)
+      g <- Graph.validateAndConstruct(Set(iInputNode, jInputNode, xDeclarationNode, xOutputNode))
+    } yield g
+
+    graph match {
+      case Valid(g) => validate(g)
+      case Invalid(errors) => fail(s"Unable to build WOM graph: ${errors.toList.mkString(" ")}")
+    }
+
+    def validate(graph: Graph) = {
+      val x_outGraphOutputNode = graph.nodes.find {
+        case g: GraphOutputNode => g.name == "x_out"
+        case _ => false
+      }.getOrElse(fail("No 'x_out' GraphOutputNode in the graph"))
+
+      x_outGraphOutputNode.upstream.size should be(1)
+      val xExpressionNode = x_outGraphOutputNode.upstream.head.asInstanceOf[ExpressionNode]
+      xExpressionNode.name should be("x")
+      xExpressionNode.womType should be(WdlIntegerType)
+
+      xExpressionNode.upstream should be(Set(iInputNode, jInputNode))
+    }
+  }
+
+}

--- a/wom/src/test/scala/wdl4s/wom/graph/GraphOutputNodeSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/GraphOutputNodeSpec.scala
@@ -2,8 +2,7 @@ package wdl4s.wom.graph
 
 import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.{FlatSpec, Matchers}
-import wdl4s.wdl.types.{WdlIntegerType, WdlType}
-import wdl4s.wdl.values.WdlValue
+import wdl4s.wdl.types.WdlIntegerType
 import wdl4s.wom.expression._
 
 class GraphOutputNodeSpec extends FlatSpec with Matchers {
@@ -19,11 +18,7 @@ class GraphOutputNodeSpec extends FlatSpec with Matchers {
     val jOutput = PortBasedGraphOutputNode("j_out", WdlIntegerType, jInputNode.singleOutputPort)
 
     // Declare an expression that needs both an "i" and a "j":
-    val ijExpression = new WomExpression {
-      override def inputs: Set[NamedExpressionInput] = Set(NamedExpressionInput("i", WdlIntegerType), NamedExpressionInput("j", WdlIntegerType))
-      override def evaluate(variableValues: ExpressionInputs, ioFunctionSet: IoFunctionSet): WdlValue = ???
-      override def womType: WdlType = WdlIntegerType
-    }
+    val ijExpression = PlaceholderWomExpression(Set("i", "j"), WdlIntegerType)
 
     // Declare the expression output using both i and j:
     val xOutputValidation = ExpressionBasedGraphOutputNode.linkWithInputs("x_out", ijExpression, Map(

--- a/wom/src/test/scala/wdl4s/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/ScatterNodeSpec.scala
@@ -19,7 +19,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
     runtimeAttributes = new RuntimeAttributes(Map.empty),
     meta = Map.empty,
     parameterMeta = Map.empty,
-    outputs = Set(OutputDefinition("out", WdlStringType, PlaceholderWomExpression(WdlStringType))),
+    outputs = Set(OutputDefinition("out", WdlStringType, PlaceholderWomExpression(Set.empty, WdlStringType))),
     inputs = Set(RequiredInputDefinition("i", WdlIntegerType)),
     declarations = List.empty
   )


### PR DESCRIPTION
- [x] To be rebased on develop after https://github.com/broadinstitute/wdl4s/pull/164 merges.

Easiest entry point for reviewers: the `ExpressionNodeSpec` creates the graph:

![test](https://user-images.githubusercontent.com/13006282/29184081-0e2e49fe-7dd3-11e7-86da-33d26c7d8ec8.png)

i.e. roughly equivalent to:
```
Int i
Int j
Int x = i + j # Or could be any expression of i and j
output {
  Int x_out = x
}
```