### PR TITLE
Using expressions as inputs to calls

### DIFF
--- a/wom/src/main/scala/wdl4s/wdl/CallOutput.scala
+++ b/wom/src/main/scala/wdl4s/wdl/CallOutput.scala
@@ -2,19 +2,10 @@ package wdl4s.wdl
 
 import wdl4s.parser.WdlParser.Ast
 import wdl4s.wdl.types.WdlType
-import wdl4s.wom.graph.GraphNodePort.GraphNodeOutputPort
 
-object CallOutput {
-  def buildOutputPort(callOutput: CallOutput) = {
-    GraphNodeOutputPort(callOutput.unqualifiedName, callOutput.wdlType, callOutput.call.womCallNode)
-  }
-}
-
-case class CallOutput(call: WdlCall, taskOutput: Output) extends Output {
+final case class CallOutput(call: WdlCall, taskOutput: Output) extends Output {
   override lazy val requiredExpression: WdlExpression = taskOutput.requiredExpression
   override lazy val ast: Ast = taskOutput.ast
   override lazy val wdlType: WdlType = taskOutput.wdlType
   override lazy val unqualifiedName: LocallyQualifiedName = taskOutput.unqualifiedName
-  
-  lazy val toWomOutputPort = CallOutput.buildOutputPort(this)
 }

--- a/wom/src/main/scala/wdl4s/wdl/WdlCall.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlCall.scala
@@ -1,6 +1,8 @@
 package wdl4s.wdl
 
-import cats.data.Validated.{Invalid, Valid}
+import cats.syntax.traverse._
+import cats.instances.list._
+import lenthall.validation.ErrorOr.ErrorOr
 import wdl4s.parser.WdlParser.{Ast, SyntaxError, Terminal}
 import wdl4s.wdl.AstTools.EnhancedAstNode
 import wdl4s.wdl.exception.{ValidationException, VariableLookupException, VariableNotFoundException}
@@ -8,8 +10,8 @@ import wdl4s.wdl.expression.WdlFunctions
 import wdl4s.wdl.types.WdlOptionalType
 import wdl4s.wdl.values.{WdlOptionalValue, WdlValue}
 import wdl4s.wom.graph.CallNode.CallWithInputs
-import wdl4s.wom.graph.GraphNodePort.GraphNodeOutputPort
-import wdl4s.wom.graph.{CallNode, GraphInputNode}
+import wdl4s.wom.graph.{CallNode, GraphInputNode, GraphNodePort}
+import cats.syntax.validated._
 
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
@@ -49,31 +51,34 @@ object WdlCall {
   }
 
 
-  private def buildWomNodeAndInputs(wdlCall: WdlCall): CallWithInputs = {
-    val inputToOutputPort: Map[String, GraphNodeOutputPort] = for {
+  private def buildWomNodeAndInputs(wdlCall: WdlCall): ErrorOr[CallWithInputs] = {
+
+    val inputToOutputPortValidations: Iterable[ErrorOr[(String, GraphNodePort.OutputPort)]] = for {
       (inputName, expr) <- wdlCall.inputMappings
       variable <- expr.variableReferences
       parent <- wdlCall.parent
       node <- parent.resolveVariable(variable.terminal.sourceString)
       outputPort = outputPortFromNode(node, variable.terminalSubIdentifier)
-    } yield inputName -> outputPort
+    } yield outputPort map { op => inputName -> op }
 
-    // TODO: When WdlExpressions wrap WomExpressions, we can use them directly and remove the 'inputToOutputPort' thing above:
-    CallNode.callWithInputs(wdlCall.alias.getOrElse(wdlCall.callable.unqualifiedName), wdlCall.callable.womDefinition, inputToOutputPort, Set.empty) match {
-      case Valid(callWithInputs) => callWithInputs
-      case Invalid(errors) => throw new Exception(s"Unable to construct WOM CallWithInputs: ${errors.toList.mkString(", ")}")
+    val inputToOutputPortValidation: ErrorOr[List[(String, GraphNodePort.OutputPort)]] = inputToOutputPortValidations.toList.sequence
+
+    // TODO: When WomExpressions wrap WdlExpressions, we can switch this to use expressionBasedInputs instead of portBasedInputs:
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    inputToOutputPortValidation flatMap { inputToOutputPort =>
+      CallNode.callWithInputs(wdlCall.alias.getOrElse(wdlCall.callable.unqualifiedName), wdlCall.callable.womDefinition, inputToOutputPort.toMap, Set.empty)
     }
   }
 
-  private def outputPortFromNode(node: WdlGraphNode, terminal: Option[Terminal]): GraphNodeOutputPort = {
+  private def outputPortFromNode(node: WdlGraphNode, terminal: Option[Terminal]): ErrorOr[GraphNodePort.OutputPort] = {
     (node, terminal) match {
       case (wdlCall: WdlCall, Some(subTerminal)) =>
-        wdlCall.womGraphOutputPorts.find(_.name == subTerminal.sourceString) getOrElse {
+        wdlCall.womGraphOutputPorts.map(_.find(_.name == subTerminal.sourceString) getOrElse {
           throw new Exception(s"Cannot find referenced variable ${subTerminal.sourceString} in call ${wdlCall.unqualifiedName}")
-        }
+        })
         // TODO implement when declarations are in WOM
-      case (_: Declaration, None) => throw new Exception("Declaration not yet supported in WOM")
-      case _ => throw new Exception(s"Unsupported node $node and terminal $terminal")
+      case (_: Declaration, None) => "Declaration not yet supported in WOM".invalidNel
+      case _ => s"Unsupported node $node and terminal $terminal".invalidNel
     }
   }
 }
@@ -98,13 +103,13 @@ sealed abstract class WdlCall(val alias: Option[String],
 
   def callType: String
 
-  private lazy val CallWithInputs(womNode, womInputs) = WdlCall.buildWomNodeAndInputs(this)
+  private lazy val womCallNodeWithInputs = WdlCall.buildWomNodeAndInputs(this)
 
-  lazy val womCallNode: CallNode = womNode
+  lazy val womCallNode: ErrorOr[CallNode] = womCallNodeWithInputs.map(_.call)
 
-  lazy val womGraphInputNodes: Set[GraphInputNode] = womInputs
+  lazy val womGraphInputNodes: ErrorOr[Set[GraphInputNode]] = womCallNodeWithInputs.map(_.inputs)
 
-  lazy val womGraphOutputPorts: Seq[GraphNodeOutputPort] = outputs.map(_.toWomOutputPort)
+  lazy val womGraphOutputPorts: ErrorOr[Set[GraphNodePort.OutputPort]] = womCallNode.map(_.outputPorts)
 
   def toCallOutput(output: Output) = output match {
     case taskOutput: TaskOutput => CallOutput(this, taskOutput.copy(parent = Option(this)))

--- a/wom/src/main/scala/wdl4s/wdl/WdlWorkflow.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlWorkflow.scala
@@ -51,7 +51,7 @@ object WdlWorkflow {
 
   def buildWomGraph(wdlWorkflow: WdlWorkflow): Graph = {
     val graphNodes = wdlWorkflow.calls.foldLeft(Set.empty[GraphNode])({
-      case (currentNodes, call) => currentNodes ++ call.womGraphInputNodes + call.womCallNode
+      case (currentNodes, call) => currentNodes ++ call.womGraphInputNodes.getOrElse(throw new Exception()) + call.womCallNode.getOrElse(throw new Exception())
     })
 
     Graph.validateAndConstruct(graphNodes) match {

--- a/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
@@ -1,10 +1,11 @@
 package wdl4s.wom.graph
 
-import cats.implicits._
+import cats.syntax.traverse._
+import cats.instances.list._
+
 import lenthall.validation.ErrorOr.ErrorOr
 import wdl4s.wom.callable.Callable.OutputDefinition
 import wdl4s.wom.callable.{Callable, TaskDefinition, WorkflowDefinition}
-import wdl4s.wom.graph.CallNode.CallWithInputs
 import wdl4s.wom.graph.GraphNode.LinkedInputPort
 import wdl4s.wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 
@@ -14,14 +15,14 @@ sealed abstract class CallNode extends GraphNode {
   def callType: String
 }
 
-final case class TaskCallNode private(name: String, callable: TaskDefinition, inputPorts: Set[GraphNodePort.InputPort]) extends CallNode {
+final case class TaskCallNode private(name: String, callable: TaskDefinition, inputPorts: Set[GraphNodePort.InputPort], inputExpressions: Map[String, InstantiatedExpression]) extends CallNode {
   val callType: String = "task"
   override val outputPorts: Set[GraphNodePort.OutputPort] = {
     callable.outputs.map(o => GraphNodeOutputPort(o.name, o.womType, this))
   }
 }
 
-final case class WorkflowCallNode private(name: String, callable: WorkflowDefinition, inputPorts: Set[GraphNodePort.InputPort]) extends CallNode {
+final case class WorkflowCallNode private(name: String, callable: WorkflowDefinition, inputPorts: Set[GraphNodePort.InputPort], inputExpressions: Map[String, InstantiatedExpression]) extends CallNode {
   val callType: String = "workflow"
   override val outputPorts: Set[GraphNodePort.OutputPort] = {
     callable.innerGraph.nodes.collect { case gon: PortBasedGraphOutputNode => GraphNodeOutputPort(gon.name, gon.womType, this) }
@@ -33,17 +34,16 @@ object TaskCall {
 
     def linkOutput(call: GraphNode)(output: OutputDefinition): ErrorOr[GraphNode] = call.outputByName(output.name).map(out => PortBasedGraphOutputNode(output.name, output.womType, out))
 
-    val CallWithInputs(call, inputs) = CallNode.callWithInputs(taskDefinition.name, taskDefinition, Map.empty)
-    val outputsValidation = taskDefinition.outputs.toList.traverse(linkOutput(call) _)
-
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
-    outputsValidation flatMap { outputs =>
-      val callSet: Set[GraphNode] = Set[GraphNode](call)
-      val inputsSet: Set[_ <: GraphNode] = inputs
-      val outputsSet: Set[GraphNode] = outputs.toSet
 
-      Graph.validateAndConstruct(callSet ++ inputsSet ++ outputsSet)
-    }
+    for {
+      callWithInputs <- CallNode.callWithInputs(taskDefinition.name, taskDefinition, Map.empty, Set.empty)
+      outputs <- taskDefinition.outputs.toList.traverse(linkOutput(callWithInputs.call) _)
+      callSet = Set[GraphNode](callWithInputs.call)
+      inputsSet = callWithInputs.inputs.toSet[GraphNode]
+      outputsSet = outputs.toSet[GraphNode]
+      graph <- Graph.validateAndConstruct(callSet ++ inputsSet ++ outputsSet)
+    } yield graph
   }
 }
 
@@ -54,29 +54,34 @@ object CallNode {
   /**
     * Create a CallNode for a Callable (task or workflow).
     *
-    * If an input is supplied, it gets wired in as appropriate.
+    * If an input is supplied as a port from another Node, it gets wired in directly.
+    * If an input is supplied as an expression, we try to create an InstantiatedExpression and include that in the call.
     * If an input is not supplied, it gets created as a GraphInputNode.
     *
-    * The returned value is a tuple of (
-    *   _1: the CallNode
-    *   _2: any GraphInputNodes we created for unsupplied inputs
-    * )
     */
-  def callWithInputs(name: String, callable: Callable, inputMapping: Map[String, OutputPort]): CallWithInputs = {
+  def callWithInputs(name: String, callable: Callable, portInputs: Map[String, OutputPort], expressionInputs: Set[GraphNodeInputExpression]): ErrorOr[CallWithInputs] = {
 
     val graphNodeSetter = new GraphNode.GraphNodeSetter()
-    val inputPortLinker = GraphNode.linkInputPort(callable.name + ".", inputMapping, graphNodeSetter.get) _
-    val linkedInputPortsAndGraphInputNodes = callable.inputs map inputPortLinker
 
-    val linkedInputPorts = linkedInputPortsAndGraphInputNodes.map(_.newInputPort)
-    val graphInputNodes = linkedInputPortsAndGraphInputNodes collect { case LinkedInputPort(_, Some(gin)) => gin }
+    val instantiatedExpressionInputsAttempt: ErrorOr[Map[String, InstantiatedExpression]] = expressionInputs.toList traverse { gnie => gnie.instantiateExpression(graphNodeSetter) } map { _.toMap }
 
-    val callNode = callable match {
-      case t: TaskDefinition => TaskCallNode(name, t, linkedInputPorts)
-      case w: WorkflowDefinition => WorkflowCallNode(name, w, linkedInputPorts)
+    instantiatedExpressionInputsAttempt map { instantiatedExpressionInputs =>
+      val inputPortLinker = GraphNode.linkInputPort(callable.name + ".", portInputs, graphNodeSetter.get) _
+
+      // Filter out the inputs we already have from expressions:
+      val asYetUnsuppliedInputs = callable.inputs.filterNot(inputDef => instantiatedExpressionInputs.contains(inputDef.name))
+      val linkedInputPortsAndGraphInputNodes = asYetUnsuppliedInputs map inputPortLinker
+
+      val linkedInputPorts = linkedInputPortsAndGraphInputNodes.map(_.newInputPort)
+      val graphInputNodes = linkedInputPortsAndGraphInputNodes collect { case LinkedInputPort(_, Some(gin)) => gin }
+
+      val callNode = callable match {
+        case t: TaskDefinition => TaskCallNode(name, t, linkedInputPorts, instantiatedExpressionInputs)
+        case w: WorkflowDefinition => WorkflowCallNode(name, w, linkedInputPorts, instantiatedExpressionInputs)
+      }
+
+      graphNodeSetter._graphNode = callNode
+      CallWithInputs(callNode, graphInputNodes)
     }
-
-    graphNodeSetter._graphNode = callNode
-    CallWithInputs(callNode, graphInputNodes)
   }
 }

--- a/wom/src/main/scala/wdl4s/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/Graph.scala
@@ -26,7 +26,7 @@ object Graph {
     def goodLink(port: InputPort): ErrorOr[Unit] = {
       val upstreamOutputPort = port.upstream
 
-      if (nodes.contains(upstreamOutputPort.graphNode)) {
+      if (nodes.exists(_ eq upstreamOutputPort.graphNode)) {
         ().validNel
       } else {
         s"The input link ${port.name} is linked to a node outside the graph set (${upstreamOutputPort.name})".invalidNel

--- a/wom/src/main/scala/wdl4s/wom/graph/GraphNodeInputExpression.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/GraphNodeInputExpression.scala
@@ -1,0 +1,10 @@
+package wdl4s.wom.graph
+
+import lenthall.validation.ErrorOr.ErrorOr
+import wdl4s.wom.expression.WomExpression
+import wdl4s.wom.graph.GraphNode.GraphNodeSetter
+import wdl4s.wom.graph.GraphNodePort.OutputPort
+
+case class GraphNodeInputExpression(inputName: String, expression: WomExpression, inputMapping: Map[String, OutputPort]) {
+  private[graph] def instantiateExpression(graphNodeSetter: GraphNodeSetter): ErrorOr[(String, InstantiatedExpression)] = InstantiatedExpression.linkWithInputs(graphNodeSetter, expression, inputMapping) map { (inputName, _) }
+}

--- a/wom/src/test/scala/wdl4s/wom/callable/TaskDefinitionSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/callable/TaskDefinitionSpec.scala
@@ -4,6 +4,7 @@ import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.{FlatSpec, Matchers}
 import wdl4s.wdl.types.{WdlIntegerType, WdlStringType}
 import wdl4s.wom.graph.{CallNode, GraphInputNode, PortBasedGraphOutputNode}
+import wdl4s.wom.callable.TaskDefinitionSpec._
 
 class TaskDefinitionSpec extends FlatSpec with Matchers {
 
@@ -11,19 +12,7 @@ class TaskDefinitionSpec extends FlatSpec with Matchers {
   behavior of "TaskDefinition.graph"
 
   it should "represent an empty task as a one-node TaskCall graph" in {
-    val task = TaskDefinition(
-      name = "foo",
-      commandTemplate = Seq.empty,
-      runtimeAttributes = null,
-      meta = Map.empty,
-      parameterMeta = Map.empty,
-      outputs = Set.empty,
-      inputs = Set.empty,
-      declarations = List.empty)
-
-    val graphValidation = task.graph
-
-    graphValidation match {
+    noInputsOrOutputsTask.graph match {
       case Valid(graph) =>
         graph.nodes.size should be(1)
       case Invalid(l) => fail(s"Failed to construct a one-node TaskCall graph: ${l.toList.mkString(", ")}")
@@ -31,19 +20,7 @@ class TaskDefinitionSpec extends FlatSpec with Matchers {
   }
 
   it should "create a graph input node for a one-input task definition" in {
-    val task = TaskDefinition(
-      name = "foo",
-      commandTemplate = Seq.empty,
-      runtimeAttributes = null,
-      meta = Map.empty,
-      parameterMeta = Map.empty,
-      outputs = Set.empty,
-      inputs = Set(Callable.RequiredInputDefinition("bar", WdlIntegerType)),
-      declarations = List.empty)
-
-    val graphValidation = task.graph
-
-    graphValidation match {
+    oneInputTask.graph match {
       case Valid(graph) =>
         graph.nodes.size should be(2)
         (graph.nodes.toList.find(_.isInstanceOf[GraphInputNode]), graph.nodes.toList.find(_.isInstanceOf[CallNode])) match {
@@ -57,19 +34,7 @@ class TaskDefinitionSpec extends FlatSpec with Matchers {
   }
 
   it should "create a graph output node for a one-output task definitions" in {
-    val task = TaskDefinition(
-      name = "foo",
-      commandTemplate = Seq.empty,
-      runtimeAttributes = null,
-      meta = Map.empty,
-      parameterMeta = Map.empty,
-      outputs = Set(Callable.OutputDefinition("bar", WdlStringType, null)),
-      inputs = Set(),
-      declarations = List.empty)
-
-    val graphValidation = task.graph
-
-    graphValidation match {
+    oneOutputTask.graph match {
       case Valid(graph) =>
         graph.nodes.size should be(2)
         (graph.nodes.toList.find(_.isInstanceOf[PortBasedGraphOutputNode]), graph.nodes.toList.find(_.isInstanceOf[CallNode])) match {
@@ -82,4 +47,37 @@ class TaskDefinitionSpec extends FlatSpec with Matchers {
       case Invalid(l) => fail(s"Failed to construct a one-input TaskCall graph: ${l.toList.mkString(", ")}")
     }
   }
+}
+
+object TaskDefinitionSpec {
+
+  val noInputsOrOutputsTask = TaskDefinition(
+    name = "foo",
+    commandTemplate = Seq.empty,
+    runtimeAttributes = null,
+    meta = Map.empty,
+    parameterMeta = Map.empty,
+    outputs = Set.empty,
+    inputs = Set.empty,
+    declarations = List.empty)
+
+  val oneInputTask = TaskDefinition(
+    name = "foo",
+    commandTemplate = Seq.empty,
+    runtimeAttributes = null,
+    meta = Map.empty,
+    parameterMeta = Map.empty,
+    outputs = Set.empty,
+    inputs = Set(Callable.RequiredInputDefinition("bar", WdlIntegerType)),
+    declarations = List.empty)
+
+  val oneOutputTask = TaskDefinition(
+    name = "foo",
+    commandTemplate = Seq.empty,
+    runtimeAttributes = null,
+    meta = Map.empty,
+    parameterMeta = Map.empty,
+    outputs = Set(Callable.OutputDefinition("bar", WdlStringType, null)),
+    inputs = Set(),
+    declarations = List.empty)
 }

--- a/wom/src/test/scala/wdl4s/wom/graph/ExpressionAsCallInputSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/ExpressionAsCallInputSpec.scala
@@ -1,0 +1,55 @@
+package wdl4s.wom.graph
+
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.wdl.types.WdlIntegerType
+import wdl4s.wom.callable.TaskDefinitionSpec
+import wdl4s.wom.expression._
+import wdl4s.wom.graph.CallNode.CallWithInputs
+
+class ExpressionAsCallInputSpec extends FlatSpec with Matchers {
+
+  behavior of "ExpressionBasedGraphOutputNode"
+
+  /**
+    * Roughly equivalent to the WDL (except that the expression could be anything):
+    *
+    * workflow foo {
+    *   Int i
+    *   Int j
+    *   Int x = i + j
+    *
+    *   output {
+    *     Int x_out = x
+    *   }
+    * }
+    *
+    */
+  it should "create and wire in InstantiatedExpressions where appropriate" in {
+    // Two inputs:
+    val iInputNode = RequiredGraphInputNode("i", WdlIntegerType)
+    val jInputNode = RequiredGraphInputNode("j", WdlIntegerType)
+
+    // Declare an expression that needs both an "i" and a "j":
+    val ijExpression = PlaceholderWomExpression(Set("i", "j"), WdlIntegerType)
+
+    def validateCallResult(callWithInputs: CallWithInputs) = {
+      callWithInputs.inputs should be(Set.empty)
+      callWithInputs.call.upstream should be(Set(iInputNode, jInputNode))
+    }
+
+    // Use that as an input to a one-input task:
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    val graph = for {
+      callNode <- CallNode.callWithInputs("foo", TaskDefinitionSpec.oneInputTask, Map.empty, Set(GraphNodeInputExpression("bar", ijExpression, Map("i" -> iInputNode.singleOutputPort, "j" -> jInputNode.singleOutputPort))))
+      _ = validateCallResult(callNode)
+      g <- Graph.validateAndConstruct(Set(iInputNode, jInputNode, callNode.call))
+    } yield g
+
+    graph match {
+      case Valid(_) => // Great!
+      case Invalid(errors) => fail(s"Unable to build WOM graph: ${errors.toList.mkString(" ")}")
+    }
+  }
+
+}

--- a/wom/src/test/scala/wdl4s/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/GraphSpec.scala
@@ -45,11 +45,11 @@ class GraphSpec extends FlatSpec with Matchers {
       declarations = List.empty
     )
 
-    val CallWithInputs(psCall, psGraphInputs) = CallNode.callWithInputs("ps", taskDefinition_ps, Map.empty)
+    val CallWithInputs(psCall, psGraphInputs) = CallNode.callWithInputs("ps", taskDefinition_ps, Map.empty, Set.empty).getOrElse(fail("Unable to call ps"))
     val ps_procsOutputPort = psCall.outputByName("procs").getOrElse(fail("Unexpectedly unable to find 'procs' output"))
 
-    val CallWithInputs(cgrepCall, cgrepGraphInputs) = CallNode.callWithInputs("cgrep", taskDefinition_cgrep, Map("in_file" -> ps_procsOutputPort))
-    val CallWithInputs(wcCall, wcGraphInputs) = CallNode.callWithInputs("wc", taskDefinition_wc, Map("in_file" -> ps_procsOutputPort))
+    val CallWithInputs(cgrepCall, cgrepGraphInputs) = CallNode.callWithInputs("cgrep", taskDefinition_cgrep, Map("in_file" -> ps_procsOutputPort), Set.empty).getOrElse(fail("Unable to call cgrep"))
+    val CallWithInputs(wcCall, wcGraphInputs) = CallNode.callWithInputs("wc", taskDefinition_wc, Map("in_file" -> ps_procsOutputPort), Set.empty).getOrElse(fail("Unable to call wc"))
 
     val graphNodes: Set[GraphNode] =
       Set[GraphNode](psCall, cgrepCall, wcCall)
@@ -73,7 +73,7 @@ class GraphSpec extends FlatSpec with Matchers {
 
   it should "be able to represent calls to sub-workflows" in {
     val threeStepWorkflow = WorkflowDefinition("three_step", makeThreeStep, Map.empty, Map.empty, List.empty)
-    val CallWithInputs(threeStepCall, threeStepInputs) = CallNode.callWithInputs("three_step", threeStepWorkflow, Map.empty)
+    val CallWithInputs(threeStepCall, threeStepInputs) = CallNode.callWithInputs("three_step", threeStepWorkflow, Map.empty, Set.empty).getOrElse(fail("Unable to call three_step"))
 
     val workflowGraph = Graph.validateAndConstruct(Set[GraphNode](threeStepCall).union(threeStepInputs.toSet[GraphNode])) match {
       case Valid(wg) => wg.withDefaultOutputs

--- a/wom/src/test/scala/wdl4s/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/ScatterNodeSpec.scala
@@ -49,7 +49,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
     val xs_inputNode = RequiredGraphInputNode("xs", WdlArrayType(WdlIntegerType))
 
     val x_inputNode = RequiredGraphInputNode("x", WdlIntegerType)
-    val CallWithInputs(foo_callNode, _) = CallNode.callWithInputs("foo", task_foo, Map("i" -> x_inputNode.singleOutputPort))
+    val CallWithInputs(foo_callNode, _) = CallNode.callWithInputs("foo", task_foo, Map("i" -> x_inputNode.singleOutputPort), Set.empty).getOrElse(fail("Unable to call foo_callNode"))
     val scatterGraph = Graph.validateAndConstruct(Set(foo_callNode, x_inputNode)) match {
       case Valid(sg) => sg.withDefaultOutputs
       case Invalid(es) => fail("Failed to make scatter graph: " + es.toList.mkString(", "))


### PR DESCRIPTION
Allows WDL and CWL to provide inputs to `CallNode`s as `WomExpression`s rather than `OutputPort`s.

Because inputs to the expressions are required to be in scope, this can now fail (hence `CallWithInputs` now returns an `ErrorOr`)