### PR TITLE
Restore null coercions

### DIFF
--- a/wom/src/main/scala/wdl4s/wdl/types/WdlOptionalType.scala
+++ b/wom/src/main/scala/wdl4s/wdl/types/WdlOptionalType.scala
@@ -1,4 +1,5 @@
 package wdl4s.wdl.types
+import spray.json.JsNull
 import wdl4s.wdl.values.{WdlOptionalValue, WdlValue}
 
 import scala.util.Try
@@ -20,6 +21,9 @@ case class WdlOptionalType(memberType: WdlType) extends WdlType {
     // Coercing inner values:
     case WdlOptionalValue(otherMemberType, Some(value)) if memberType.isCoerceableFrom(otherMemberType) => WdlOptionalValue(memberType, Option(memberType.coerceRawValue(value).get))
     case WdlOptionalValue(otherMemberType, None) if memberType.isCoerceableFrom(otherMemberType) => WdlOptionalValue(memberType, None)
+      
+    // Javascript null coerces to empty value
+    case JsNull => WdlOptionalValue(memberType, None)
   }
 
   override def isCoerceableFrom(otherType: WdlType): Boolean = otherType match {


### PR DESCRIPTION
I've been fighting various gremlins trying to leave my WdlWomExpression stuff in a good place for the start of bug rotation on Monday, but I had consistent Centaur failures in the new null handling test.  I finally tracked the problem down to wdl4s commit 3a93c7eecffe33086a02d5eb7ecdb2a9bb6ea246 which in addition to bringing in the advertised "womified 3step" also erased Thibault's changes to support null coercions in the previous commit.  This PR just cherry picks the original null coercion commit back in.