### PR TITLE
WdlWomExpressions

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   val sprayJsonV = "1.3.2"
   val circeVersion = "0.8.0"
-  val lenthallV = "0.25"
+  val lenthallV = "0.28-2ee0bd8-SNAP"
 
   // Internal collections of dependencies
 

--- a/wom/src/main/scala/wdl4s/wdl/AstTools.scala
+++ b/wom/src/main/scala/wdl4s/wdl/AstTools.scala
@@ -305,6 +305,8 @@ object AstTools {
         && a.getAttribute("lhs") == terminal
         && a.getAttribute("rhs").isTerminal => a.getAttribute("rhs").asInstanceOf[Terminal]
     }
+
+    def fullVariableReferenceString = terminal.getSourceString + (terminalSubIdentifier map { "." + _.getSourceString } getOrElse "")
   }
 
   /**

--- a/wom/src/main/scala/wdl4s/wdl/WdlExpression.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlExpression.scala
@@ -1,5 +1,7 @@
 package wdl4s.wdl
 
+import lenthall.validation.ErrorOr.ErrorOr
+import lenthall.validation.Validation._
 import wdl4s.parser.WdlParser
 import wdl4s.parser.WdlParser.{Ast, AstList, AstNode, Terminal}
 import wdl4s.wdl.AstTools.{EnhancedAstNode, VariableReference}
@@ -8,8 +10,11 @@ import wdl4s.wdl.expression._
 import wdl4s.wdl.formatter.{NullSyntaxHighlighter, SyntaxHighlighter}
 import wdl4s.wdl.types._
 import wdl4s.wdl.values._
+import wdl4s.wom.expression.{IoFunctionSet, WomExpression}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 import scala.language.postfixOps
 import scala.util.Try
 
@@ -184,6 +189,39 @@ case class WdlExpression(ast: AstNode) extends WdlValue {
   }
   def topLevelMemberAccesses: Set[MemberAccess] = AstTools.findTopLevelMemberAccesses(ast) map { MemberAccess(_) } toSet
   def variableReferences: Iterable[VariableReference] = AstTools.findVariableReferences(ast)
+}
+
+/**
+  *
+  * @param wdlExpression The wrapped WdlExpression.
+  * @param from The Scope in which the WdlExpression is found, needed to adjust member access expressions located in
+  *             conditionals (wrapped in optionals) or scatters (wrapped in arrays).
+  */
+final case class WdlWomExpression(wdlExpression: WdlExpression, from: Option[Scope]) extends WomExpression {
+
+  override def inputs: Set[String] = wdlExpression.variableReferences map { _.fullVariableReferenceString } toSet
+
+  override def evaluateValue(variableValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue] = {
+    lazy val wdlFunctions = new WdlStandardLibraryFunctions {
+      override def readFile(path: String): String = Await.result(ioFunctionSet.readFile(path), Duration.Inf)
+
+      override def writeFile(path: String, content: String): Try[WdlFile] = Try(Await.result(ioFunctionSet.writeFile(path, content), Duration.Inf))
+
+      override def stdout(params: Seq[Try[WdlValue]]): Try[WdlFile] = ioFunctionSet.stdout(params)
+
+      override def stderr(params: Seq[Try[WdlValue]]): Try[WdlFile] = ioFunctionSet.stderr(params)
+
+      override def glob(path: String, pattern: String): Seq[String] = ioFunctionSet.glob(path, pattern)
+
+      override def size(params: Seq[Try[WdlValue]]): Try[WdlFloat] = ioFunctionSet.size(params)
+    }
+    wdlExpression.evaluate(variableValues.apply, wdlFunctions).toErrorOr
+  }
+
+  override def evaluateType(inputTypes: Map[String, WdlType]): ErrorOr[WdlType] =
+    // All current usages of WdlExpression#evaluateType trace back to WdlNamespace, but this is not the
+    // case in the brave new WOM-world.
+    wdlExpression.evaluateType(inputTypes.apply, new WdlStandardLibraryFunctionsType, from).toErrorOr
 }
 
 object TernaryIf {

--- a/wom/src/main/scala/wdl4s/wdl/WdlNamespace.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlNamespace.scala
@@ -415,10 +415,10 @@ object WdlNamespace {
   /**
     * Determine the list of references in this expression to values which were never declared
     */
-  def referencesToAbsentValues(container: Scope, expression: WdlExpression): Iterable[Terminal] =
+  private def referencesToAbsentValues(container: Scope, expression: WdlExpression): Iterable[Terminal] =
     expression.variableReferences collect { case variable if container.resolveVariable(variable.terminal.sourceString).isEmpty => variable.terminal }
 
-  def validateDeclaration(declaration: DeclarationInterface, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Seq[SyntaxError] = {
+  private def validateDeclaration(declaration: DeclarationInterface, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Seq[SyntaxError] = {
     val invalidVariableReferences = for {
       expr <- declaration.expression.toSeq
       variable <- referencesToAbsentValues(declaration, expr)
@@ -432,7 +432,7 @@ object WdlNamespace {
     invalidVariableReferences ++ typeMismatches
   }
 
-  def lookupType(from: Scope)(n: String): WdlType = {
+  private def lookupType(from: Scope)(n: String): WdlType = {
     val resolved = from.resolveVariable(n)
     resolved match {
       case Some(d: DeclarationInterface) => d.relativeWdlType(from)
@@ -446,7 +446,7 @@ object WdlNamespace {
     }
   }
   
-  def typeCheckDeclaration(decl: DeclarationInterface, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Option[SyntaxError] = {
+  private def typeCheckDeclaration(decl: DeclarationInterface, wdlSyntaxErrorFormatter: WdlSyntaxErrorFormatter): Option[SyntaxError] = {
     decl.expression flatMap { expr =>
       expr.evaluateType(lookupType(decl), new WdlStandardLibraryFunctionsType, Option(decl)) match {
         case Success(wdlType) =>

--- a/wom/src/main/scala/wdl4s/wdl/expression/TypeEvaluator.scala
+++ b/wom/src/main/scala/wdl4s/wdl/expression/TypeEvaluator.scala
@@ -96,6 +96,8 @@ case class TypeEvaluator(override val lookup: String => WdlType, override val fu
               }
             case ns: WdlNamespace => Success(lookup(ns.importedAs.map{ n => s"$n.${rhs.getSourceString}" }.getOrElse(rhs.getSourceString)))
             case _ => Failure(new WdlExpressionException("Left-hand side of expression must be a WdlObject or Namespace"))
+          } recoverWith {
+            case _ => Try(lookup(a.getAttribute("lhs").sourceString + "." + rhs.sourceString))
           }
         case _ => Failure(new WdlExpressionException("Right-hand side of expression must be identifier"))
       }

--- a/wom/src/main/scala/wdl4s/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wdl4s/wom/expression/WomExpression.scala
@@ -3,9 +3,10 @@ package wdl4s.wom.expression
 import cats.data.Validated.Valid
 import lenthall.validation.ErrorOr.ErrorOr
 import wdl4s.wdl.types.WdlType
-import wdl4s.wdl.values.WdlValue
+import wdl4s.wdl.values.{WdlFile, WdlFloat, WdlString, WdlValue}
 
 import scala.concurrent.Future
+import scala.util.Try
 
 trait WomExpression {
   def inputs: Set[String]
@@ -14,17 +15,25 @@ trait WomExpression {
 }
 
 final case class PlaceholderWomExpression(inputs: Set[String], fixedWomType: WdlType) extends WomExpression {
-  override def evaluateValue(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue] = ???
+  override def evaluateValue(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue] = Valid(WdlString("42"))
   override def evaluateType(inputTypes: Map[String, WdlType]): ErrorOr[WdlType] = Valid(fixedWomType)
 }
 
 // TODO: Flesh this out (https://github.com/broadinstitute/cromwell/issues/2521)
 trait IoFunctionSet {
-  def read_file(path: String): Future[String]
-  def write_file(path: String, content: String): Future[Unit]
+  def readFile(path: String): Future[String]
+  def writeFile(path: String, content: String): Future[WdlFile]
+  def stdout(params: Seq[Try[WdlValue]]): Try[WdlFile]
+  def stderr(params: Seq[Try[WdlValue]]): Try[WdlFile]
+  def glob(path: String, pattern: String): Seq[String]
+  def size(params: Seq[Try[WdlValue]]): Try[WdlFloat]
 }
 
 case object PlaceholderIoFunctionSet extends IoFunctionSet {
-  override def read_file(path: String): Future[String] = Future.successful("35")
-  override def write_file(path: String, content: String): Future[Unit] = Future.successful(())
+  override def readFile(path: String): Future[String] = ???
+  override def writeFile(path: String, content: String): Future[WdlFile] = ???
+  override def stdout(params: Seq[Try[WdlValue]]) = ???
+  override def stderr(params: Seq[Try[WdlValue]]) = ???
+  override def glob(path: String, pattern: String) = ???
+  override def size(params: Seq[Try[WdlValue]]) = ???
 }

--- a/wom/src/main/scala/wdl4s/wom/graph/InstantiatedExpression.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/InstantiatedExpression.scala
@@ -30,7 +30,7 @@ object InstantiatedExpression {
       val upstreamPort = inputMapping(input)
       Valid((input, ConnectedInputPort(input, upstreamPort.womType, upstreamPort, graphNodeSetter.get)))
     } else {
-      s"Expression cannot be connected without the input $input.".invalidNel
+      s"Expression cannot be connected without the input $input (provided: ${inputMapping.toString})".invalidNel
     }
 
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap

--- a/wom/src/test/scala/wdl4s/wdl/expression/ValueEvaluatorSpec.scala
+++ b/wom/src/test/scala/wdl4s/wdl/expression/ValueEvaluatorSpec.scala
@@ -57,7 +57,7 @@ class ValueEvaluatorSpec extends FlatSpec with Matchers {
 
     override def readFile(path: String): String = throw new NotImplementedError()
 
-    override def writeTempFile(path: String, prefix: String, suffix: String, content: String): String = throw new NotImplementedError()
+    override def writeFile(path: String, content: String): Try[WdlFile] = Failure(new NotImplementedError())
 
     override def stdout(params: Seq[Try[WdlValue]]): Try[WdlFile] = Failure(new NotImplementedError())
 

--- a/wom/src/test/scala/wdl4s/wdl/expression/WdlStandardLibraryFunctionsSpec.scala
+++ b/wom/src/test/scala/wdl4s/wdl/expression/WdlStandardLibraryFunctionsSpec.scala
@@ -52,6 +52,7 @@ case object TestableFunctions extends WdlStandardLibraryFunctions {
   // No need to test the ones that are overridden anyway:
   // TODO: Can replace with "OnlyPureFunctions when that branch merges..."
   override def readFile(path: String): String = throw new NotImplementedException("")
+  override def writeFile(path: String, content: String): Try[WdlFile] = throw new NotImplementedException("")
   override def range(params: Seq[Try[WdlValue]]): Try[WdlArray] = throw new NotImplementedException("")
   override def read_json(params: Seq[Try[WdlValue]]): Try[WdlValue] = throw new NotImplementedException("")
   override def write_json(params: Seq[Try[WdlValue]]): Try[WdlFile] = throw new NotImplementedException("")
@@ -63,7 +64,6 @@ case object TestableFunctions extends WdlStandardLibraryFunctions {
   override def stdout(params: Seq[Try[WdlValue]]): Try[WdlFile] = throw new NotImplementedException("")
   override def glob(path: String, pattern: String): Seq[String] = throw new NotImplementedException("")
   override def stderr(params: Seq[Try[WdlValue]]): Try[WdlFile] = throw new NotImplementedException("")
-  override def writeTempFile(path: String, prefix: String, suffix: String, content: String): String = throw new NotImplementedException("")
 }
 
 case object TestableFunctionTypes extends WdlStandardLibraryFunctionsType

--- a/wom/src/test/scala/wdl4s/wdl/wom/WdlWomExpressionsAsInputsSpec.scala
+++ b/wom/src/test/scala/wdl4s/wdl/wom/WdlWomExpressionsAsInputsSpec.scala
@@ -1,0 +1,79 @@
+package wdl4s.wdl.wom
+
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.wdl.wom.WdlWomExpressionsAsInputsSpec.Wdl
+import wdl4s.wdl.{WdlNamespace, WdlNamespaceWithWorkflow}
+import wdl4s.wom.graph.TaskCallNode
+
+import scala.language.postfixOps
+
+
+object WdlWomExpressionsAsInputsSpec {
+  val Wdl =
+    // Using calls as inputs since declaration inputs are currently not supported.
+    """
+      |workflow foo {
+      |    call a
+      |    call b
+      |
+      |    call c { input: int_in = a.int_out + b.int_out }
+      |}
+      |
+      |task a {
+      |    Int int_in
+      |    command {}
+      |    output {
+      |        Int int_out = int_in
+      |    }
+      |}
+      |
+      |task b {
+      |    Int int_in
+      |    command {}
+      |    output {
+      |        Int int_out = int_in
+      |    }
+      |}
+      |
+      |task c {
+      |    Int int_in
+      |    command {}
+      |    output {
+      |        Int int_out = int_in
+      |    }
+      |}
+    """.stripMargin
+}
+
+
+class WdlWomExpressionsAsInputsSpec extends FlatSpec with Matchers {
+  behavior of "WdlWomExpressionsAsInputs"
+
+  it should "wire up input expressions for a WDL workflow" in {
+
+    val namespace = WdlNamespace.loadUsingSource(Wdl, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+
+    val workflowGraph = namespace.womExecutable.flatMap(_.graph) match {
+      case Valid(g) => g
+      case Invalid(errors) => fail(s"Unable to build wom graph from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
+    }
+
+    val callNodes = workflowGraph.nodes.toList collect { case callNode: TaskCallNode => callNode.name -> callNode } toMap
+
+    val c = callNodes("c")
+    c.expressionBasedInputs should have size 1
+    val inputExpression = c.expressionBasedInputs.values.head
+
+    List("a", "b") foreach { x =>
+      val connectedInputPort = inputExpression.inputMapping(s"$x.int_out")
+      val upstream = connectedInputPort.upstream
+      upstream.name shouldBe "int_out"
+      val upstreamTaskCallNode = upstream.graphNode.asInstanceOf[TaskCallNode]
+      upstreamTaskCallNode.name shouldBe x
+      // Instance equality test
+      (upstreamTaskCallNode eq callNodes(x)) shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
Many thanks to @cjllanwarne for his WDL-wizardry.  Lessons were learned:

* Several required functions were missing from `IoFunctionSet`.
* The signatures of `IoFunctionSet` functions were wisely designed to return `Future[T]`.  The signatures of WDL functions return `T`.  Guess what the WDL implementations do to bridge this difference.  :nauseated_face: 
* Warning: changes in `TypeEvaluator` are more disgusting than they appear.  Basically we try a bunch of convoluted lookup logic and if that fails, eh just consult the lookup function that was passed in instead.  That will probably break down for expressions in scatters or conditionals.
* The cleanliness of the `IoFunctionSet` design inspired / necessitated some Cromwell refactoring, represented in a forthcoming Cromwell PR.

