### PR TITLE
WDL declarations as WOM nodes

### DIFF
--- a/wom/src/main/scala/wdl4s/wdl/WdlGraphNode.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlGraphNode.scala
@@ -1,6 +1,11 @@
 package wdl4s.wdl
 
+import cats.syntax.option._
+import cats.syntax.validated._
+import lenthall.validation.ErrorOr.ErrorOr
+import wdl4s.parser.WdlParser.Terminal
 import wdl4s.wdl.AstTools.{EnhancedAstNode, VariableReference}
+import wdl4s.wom.graph.GraphNodePort
 
 sealed trait WdlGraphNode extends Scope {
 
@@ -39,6 +44,24 @@ object WdlGraphNode {
     val setWithUpstream = currentSet ++ graphNode.upstream
     val updatesNeeded = graphNode.upstream -- currentSet
     updatesNeeded.foldLeft(setWithUpstream)(calculateUpstreamAncestry)
+  }
+
+  private[wdl] def outputPortFromNode(node: WdlGraphNode, terminal: Option[Terminal]): ErrorOr[GraphNodePort.OutputPort] = {
+
+    def findNamedOutputPort(name: String, graphOutputPorts: Set[GraphNodePort.OutputPort], terminalName: String): ErrorOr[GraphNodePort.OutputPort] = {
+      graphOutputPorts.find(_.name == name).toValidNel(s"Cannot find an output port $name in $terminalName")
+    }
+
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    (node, terminal) match {
+      case (wdlCall: WdlCall, Some(subTerminal)) =>
+        for {
+          graphOutputPorts <- wdlCall.womGraphOutputPorts
+          namedPort <- findNamedOutputPort(subTerminal.sourceString, graphOutputPorts, "call " + wdlCall.unqualifiedName)
+        } yield namedPort
+      case (declaration: Declaration, None) => declaration.womExpressionNode.map(_.singleOutputPort)
+      case _ => s"Unsupported node $node and terminal $terminal".invalidNel
+    }
   }
 }
 

--- a/wom/src/main/scala/wdl4s/wdl/WdlWorkflow.scala
+++ b/wom/src/main/scala/wdl4s/wdl/WdlWorkflow.scala
@@ -1,5 +1,6 @@
 package wdl4s.wdl
 
+import wdl4s.wdl.Declaration._
 import cats.syntax.cartesian._
 import cats.syntax.traverse._
 import cats.instances.list._
@@ -52,16 +53,19 @@ object WdlWorkflow {
   }
 
   def buildWomGraph(wdlWorkflow: WdlWorkflow): ErrorOr[Graph] = {
-    val graphNodesValidation = wdlWorkflow.calls.toList.traverse[ErrorOr, Set[GraphNode]] { call =>
+    val callNodesValidation = wdlWorkflow.calls.toList.traverse[ErrorOr, Set[GraphNode]] { call =>
         (call.womGraphInputNodes |@| call.womCallNode) map { (womGraphInputsNodes, womCallNode) =>
           womGraphInputsNodes.toSet[GraphNode] + womCallNode
         }
     }
 
+    val declarationsValidation: ErrorOr[List[DeclarationNode]] = wdlWorkflow.declarations.toList.traverse[ErrorOr, DeclarationNode] { decl => decl.womExpressionNode }
+
+    val callsAndDeclarationValidation = callNodesValidation |@| declarationsValidation map { (callNodes, declarationNodes) => callNodes.flatten.toSet ++ declarationNodes.map(_.toGraphNode) }
+
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
     for {
-      graphNodeSets <- graphNodesValidation
-      graphNodes = graphNodeSets.flatten.toSet
+      graphNodes <- callsAndDeclarationValidation
       g <- Graph.validateAndConstruct(graphNodes)
       withOutputs = g.withDefaultOutputs
     } yield withOutputs

--- a/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
@@ -10,7 +10,6 @@ import wdl4s.wom.graph.GraphNode.LinkedInputPort
 import wdl4s.wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 
 sealed abstract class CallNode extends GraphNode {
-  def name: String
   def callable: Callable
   def callType: String
 
@@ -20,14 +19,14 @@ sealed abstract class CallNode extends GraphNode {
   override final val inputPorts = portBasedInputs ++ expressionBasedInputs.values.flatMap(_.inputPorts)
 }
 
-final case class TaskCallNode private(name: String, callable: TaskDefinition, portBasedInputs: Set[GraphNodePort.InputPort], expressionBasedInputs: Map[String, InstantiatedExpression]) extends CallNode {
+final case class TaskCallNode private(override val name: String, callable: TaskDefinition, portBasedInputs: Set[GraphNodePort.InputPort], expressionBasedInputs: Map[String, InstantiatedExpression]) extends CallNode {
   val callType: String = "task"
   override val outputPorts: Set[GraphNodePort.OutputPort] = {
     callable.outputs.map(o => GraphNodeOutputPort(o.name, o.womType, this))
   }
 }
 
-final case class WorkflowCallNode private(name: String, callable: WorkflowDefinition, portBasedInputs: Set[GraphNodePort.InputPort], expressionBasedInputs: Map[String, InstantiatedExpression]) extends CallNode {
+final case class WorkflowCallNode private(override val name: String, callable: WorkflowDefinition, portBasedInputs: Set[GraphNodePort.InputPort], expressionBasedInputs: Map[String, InstantiatedExpression]) extends CallNode {
   val callType: String = "workflow"
   override val outputPorts: Set[GraphNodePort.OutputPort] = {
     callable.innerGraph.nodes.collect { case gon: GraphOutputNode => GraphNodeOutputPort(gon.name, gon.womType, this) }

--- a/wom/src/main/scala/wdl4s/wom/graph/ExpressionNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/ExpressionNode.scala
@@ -5,7 +5,7 @@ import lenthall.validation.ErrorOr.ErrorOr
 import wdl4s.wom.expression.WomExpression
 import wdl4s.wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 
-case class ExpressionNode private(name: String, instantiatedExpression: InstantiatedExpression) extends GraphNode {
+final case class ExpressionNode private(override val name: String, instantiatedExpression: InstantiatedExpression) extends GraphNode {
 
   val womType = instantiatedExpression.womReturnType
   val singleExpressionOutputPort = GraphNodeOutputPort(name, womType, this)

--- a/wom/src/main/scala/wdl4s/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/Graph.scala
@@ -35,7 +35,7 @@ object Graph {
 
     def upstreamNodeInGraph(port: InputPort): ErrorOr[Unit] = {
       val upstreamOutputPort = port.upstream
-      boolToErrorOr(nodes.exists(_ eq upstreamOutputPort.graphNode), s"The input link ${port.name} is linked to a node outside the graph set (${upstreamOutputPort.name})")
+      boolToErrorOr(nodes.exists(_ eq upstreamOutputPort.graphNode), s"The input link ${port.name} on ${port.graphNode.name} is linked to a node outside the graph set (${upstreamOutputPort.name})")
     }
 
     def portProperlyEmbedded(port: GraphNodePort, portFinder: GraphNode => Set[_ <: GraphNodePort]): ErrorOr[Unit] = {

--- a/wom/src/main/scala/wdl4s/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/GraphInputNode.scala
@@ -5,7 +5,6 @@ import wdl4s.wom.expression.WomExpression
 import wdl4s.wom.graph.GraphNodePort.GraphNodeOutputPort
 
 sealed trait GraphInputNode extends GraphNode {
-  def name: String
   def womType: WdlType
   val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(name, womType, this)
 
@@ -13,6 +12,6 @@ sealed trait GraphInputNode extends GraphNode {
   override val outputPorts: Set[GraphNodePort.OutputPort] = Set(singleOutputPort)
 }
 
-final case class RequiredGraphInputNode(name: String, womType: WdlType) extends GraphInputNode
-final case class OptionalGraphInputNode(name: String, womType: WdlOptionalType) extends GraphInputNode
-final case class OptionalGraphInputNodeWithDefault(name: String, womType: WdlType, default: WomExpression) extends GraphInputNode
+final case class RequiredGraphInputNode(override val name: String, womType: WdlType) extends GraphInputNode
+final case class OptionalGraphInputNode(override val name: String, womType: WdlOptionalType) extends GraphInputNode
+final case class OptionalGraphInputNodeWithDefault(override val name: String, womType: WdlType, default: WomExpression) extends GraphInputNode

--- a/wom/src/main/scala/wdl4s/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/GraphNode.scala
@@ -9,6 +9,8 @@ import wdl4s.wom.callable.Callable.{OptionalInputDefinition, OptionalInputDefini
 
 trait GraphNode {
 
+  def name: String
+
   /**
     * Inputs that must be available before this graph node can be run.
     */

--- a/wom/src/main/scala/wdl4s/wom/graph/GraphOutputNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/GraphOutputNode.scala
@@ -6,7 +6,6 @@ import wdl4s.wom.expression.WomExpression
 import wdl4s.wom.graph.GraphNodePort.{ConnectedInputPort, OutputPort}
 
 sealed trait GraphOutputNode extends GraphNode {
-  def name: String
   def womType: WdlType
 
   final override val outputPorts: Set[GraphNodePort.OutputPort] = Set.empty
@@ -15,7 +14,7 @@ sealed trait GraphOutputNode extends GraphNode {
 /**
   * Exposes an existing output port as a graph output.
   */
-final case class PortBasedGraphOutputNode(name: String, womType: WdlType, source: OutputPort) extends GraphOutputNode {
+final case class PortBasedGraphOutputNode(override val name: String, womType: WdlType, source: OutputPort) extends GraphOutputNode {
   override val inputPorts: Set[GraphNodePort.InputPort] = Set(ConnectedInputPort(name, womType, source, _ => this))
 }
 
@@ -24,7 +23,7 @@ final case class PortBasedGraphOutputNode(name: String, womType: WdlType, source
   *
   * NB: Construct this via ExpressionBasedGraphOutputNode.linkWithInputs(...)
   */
-final case class ExpressionBasedGraphOutputNode private(name: String, instantiatedExpression: InstantiatedExpression) extends GraphOutputNode {
+final case class ExpressionBasedGraphOutputNode private(override val name: String, instantiatedExpression: InstantiatedExpression) extends GraphOutputNode {
   override val womType = instantiatedExpression.womReturnType
   override val inputPorts = instantiatedExpression.inputPorts
 }

--- a/wom/src/main/scala/wdl4s/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/ScatterNode.scala
@@ -21,6 +21,8 @@ final case class ScatterNode private(graph: Graph,
                                      otherInputPorts: Set[InputPort],
                                      outputMapping: Set[ScatterGathererPort]) extends GraphNode {
 
+  override val name: String = "ScatterNode"
+
   def innerGraphInputs: Set[GraphInputNode] = graph.nodes.collect { case gin: GraphInputNode => gin }
 
   // NB if you find yourself calling .filter on this set of inputPorts, you probably just wanted to access either


### PR DESCRIPTION
- [x] Needs rebase to develop after https://github.com/broadinstitute/wdl4s/pull/180
- Replaces https://github.com/broadinstitute/wdl4s/pull/181

Converts this WDL:
```
workflow foo {
    Int a       
    Int b = 5   
    Int c = b   
    Int? d      
    Int? e = 6  
    Int? f = d

    call bar { input: int_in = a + b + c, opt_ints_in = select_all([d, e, f]) }
}

task bar {
    Int int_in
    Array[Int] opt_ints_in
    command {}
    output {
        Int int_out = int_in
        Array[Int] opt_ints_out = opt_ints_in
    }
}
```

Into this WOM:
![test](https://user-images.githubusercontent.com/13006282/29574140-b51de576-872e-11e7-8764-e77fd9853ad0.png)
