### PR TITLE
Scatters wired from WDL into WOM

### DIFF
--- a/cwl/src/main/scala/wdl4s/cwl/package.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/package.scala
@@ -3,10 +3,12 @@ package wdl4s
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string._
 import eu.timepit.refined._
+import lenthall.validation.ErrorOr.ErrorOr
 import wdl4s.cwl.CwlType.CwlType
 import wdl4s.cwl.CwlType._
 import wdl4s.wdl.types._
 import shapeless._
+import wdl4s.wom.executable.Executable
 
 /**
  * This package is intended to parse all CWL files.
@@ -72,4 +74,12 @@ package object cwl extends TypeAliases {
 
   type WdlTypeMap = Map[String, WdlType]
 
+  object CwlToWomExecutable extends Poly1 {
+    implicit def caseClt = at[CommandLineTool](clt => clt.womExecutable)
+    implicit def caseWf = at[Workflow](wf => wf.womExecutable)
+  }
+
+  implicit class CwlHelper(val cwl: Cwl) extends AnyVal {
+    def womExecutable: ErrorOr[Executable] = cwl.fold(CwlToWomExecutable)
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   val sprayJsonV = "1.3.2"
   val circeVersion = "0.8.0"
-  val lenthallV = "0.28-9440cc0-SNAP"
+  val lenthallV = "0.28-9b7fe69-SNAP"
 
   // Internal collections of dependencies
 

--- a/wom/src/main/scala/wdl4s/wdl/Scatter.scala
+++ b/wom/src/main/scala/wdl4s/wdl/Scatter.scala
@@ -1,18 +1,14 @@
 package wdl4s.wdl
 
+import cats.data.Validated.Valid
+import cats.syntax.apply._
+import cats.syntax.validated._
+import lenthall.validation.ErrorOr.ErrorOr
+import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
 import wdl4s.parser.WdlParser.{Ast, Terminal}
-
-object Scatter {
-  val FQNIdentifier = "$scatter"
-
-  /**
-   * @param index Index of the scatter block. The index is computed during tree generation to reflect wdl scatter blocks structure.
-   */
-  def apply(ast: Ast, index: Int): Scatter = {
-    val item = ast.getAttribute("item").asInstanceOf[Terminal].getSourceString
-    new Scatter(index, item, WdlExpression(ast.getAttribute("collection")), ast)
-  }
-}
+import wdl4s.wdl.types.WdlArrayType
+import wdl4s.wom.graph.{Graph, GraphNodePort, RequiredGraphInputNode, ScatterNode}
+import wdl4s.wom.graph.ScatterNode.ScatterNodeWithInputs
 
 /**
  * Scatter class.
@@ -27,4 +23,35 @@ case class Scatter(index: Int, item: String, collection: WdlExpression, ast: Ast
   final val upstreamReferences = collection.variableReferences
 
   override def toString: String = s"[Scatter fqn=$fullyQualifiedName, item=$item, collection=${collection.toWdlString}]"
+}
+
+object Scatter {
+  val FQNIdentifier = "$scatter"
+
+  /**
+    * @param index Index of the scatter block. The index is computed during tree generation to reflect wdl scatter blocks structure.
+    */
+  def apply(ast: Ast, index: Int): Scatter = {
+    val item = ast.getAttribute("item").asInstanceOf[Terminal].getSourceString
+    new Scatter(index, item, WdlExpression(ast.getAttribute("collection")), ast)
+  }
+
+  def womScatterNode(scatter: Scatter, localLookup: Map[String, GraphNodePort.OutputPort]): ErrorOr[ScatterNodeWithInputs] = {
+    val scatterCollectionExpression = WdlWomExpression(scatter.collection, Option(scatter))
+    val scatterVariableSourceValidation = WdlWomExpression.findInputsforExpression(scatter.item, scatterCollectionExpression, localLookup, Map.empty)
+    val scatterItemTypeValidation = scatterCollectionExpression.evaluateType(localLookup.map { case (k, v) => k -> v.womType }) flatMap {
+      case WdlArrayType(itemType) => Valid(itemType) // Covers maps because this is a custom unapply
+      case other => s"Cannot scatter over a non-array type ${other.toWdlString}".invalidNel
+    }
+
+    val innerGraphAndScatterItemInputValidation: ErrorOr[(Graph, RequiredGraphInputNode)] = for {
+      scatterItemType <- scatterItemTypeValidation
+      womInnerGraphScatterVariableInput = RequiredGraphInputNode(scatter.item, scatterItemType)
+      g <- WdlGraphNode.buildWomGraph(scatter, Set(womInnerGraphScatterVariableInput), localLookup)
+    } yield (g, womInnerGraphScatterVariableInput)
+
+    (scatterVariableSourceValidation, innerGraphAndScatterItemInputValidation).tupled flatMap { case (scatterVariableSource, (innerGraph, scatterItemInputNode)) =>
+      ScatterNode.scatterOverGraph(innerGraph, scatterVariableSource, scatterItemInputNode, localLookup)
+    }
+  }
 }

--- a/wom/src/main/scala/wdl4s/wdl/Scope.scala
+++ b/wom/src/main/scala/wdl4s/wdl/Scope.scala
@@ -1,5 +1,6 @@
 package wdl4s.wdl
 
+import lenthall.collections.EnhancedCollections._
 import wdl4s.parser.WdlParser.Ast
 import wdl4s.wdl.exception.{ScatterIndexNotFound, VariableLookupException, VariableNotFoundException}
 import wdl4s.wdl.expression.WdlFunctions
@@ -33,6 +34,9 @@ trait Scope {
       this._children = children
     } else throw new UnsupportedOperationException("children is write-once")
   }
+
+  lazy val childGraphNodes: Set[WdlGraphNode] = children.toSet.filterByType[WdlGraphNode]
+  lazy val childGraphNodesSorted: List[WdlGraphNode] = childGraphNodes.toList.sortWith((first, second) => first.isUpstreamFrom(second))
 
   /**
     * Containing namespace

--- a/wom/src/main/scala/wdl4s/wdl/types/WdlArrayType.scala
+++ b/wom/src/main/scala/wdl4s/wdl/types/WdlArrayType.scala
@@ -47,17 +47,11 @@ sealed trait WdlArrayType extends WdlType {
 
   override def isCoerceableFrom(otherType: WdlType): Boolean = otherType match {
     case WdlArrayType(otherMemberType) => memberType.isCoerceableFrom(otherMemberType) || otherMemberType == WdlNothingType
-    case mapType: WdlMapType => matchesMapType(mapType)
+    case mapType: WdlMapType => isCoerceableFrom(mapType.equivalentArrayType)
     case _ => false
   }
 
   def asNonEmptyArrayType = WdlNonEmptyArrayType(memberType)
-
-  private def matchesMapType(wdlMapType: WdlMapType) = (this, wdlMapType) match {
-    case (WdlArrayType(WdlPairType(leftType, rightType)), WdlMapType(keyType, valueType)) => leftType.isCoerceableFrom(keyType) && rightType.isCoerceableFrom(valueType)
-    case _ => false
-  }
-
 }
 
 case class WdlMaybeEmptyArrayType(memberType: WdlType) extends WdlArrayType {
@@ -82,6 +76,7 @@ object WdlArrayType {
   def unapply(wdlType: WdlType): Option[WdlType] = {
     wdlType match {
       case arrayType: WdlArrayType => Option(arrayType.memberType)
+      case mapType: WdlMapType => Option(mapType.equivalentArrayType.memberType)
       case _ => None
     }
   }

--- a/wom/src/main/scala/wdl4s/wdl/types/WdlMapType.scala
+++ b/wom/src/main/scala/wdl4s/wdl/types/WdlMapType.scala
@@ -19,4 +19,6 @@ case class WdlMapType(keyType: WdlType, valueType: WdlType) extends WdlType {
     case WdlObjectType => keyType.isCoerceableFrom(WdlStringType) && valueType.isCoerceableFrom(WdlStringType)
     case _ => false
   }
+
+  def equivalentArrayType: WdlArrayType = WdlArrayType(WdlPairType(keyType, valueType))
 }

--- a/wom/src/main/scala/wdl4s/wdl/types/WdlType.scala
+++ b/wom/src/main/scala/wdl4s/wdl/types/WdlType.scala
@@ -65,7 +65,7 @@ trait WdlType {
     ast.wdlValue(this, wdlSyntaxErrorFormatter)
   }
 
-  def invalid(operation: String) = Failure(new WdlExpressionException(s"Cannot perform operation: $operation"))
+  def invalid(operation: String) = Failure(new WdlExpressionException(s"Type evaluation cannot determine type from expression: $operation"))
   def add(rhs: WdlType): Try[WdlType] = invalid(s"$this + $rhs")
   def subtract(rhs: WdlType): Try[WdlType] = invalid(s"$this - $rhs")
   def multiply(rhs: WdlType): Try[WdlType] = invalid(s"$this * $rhs")

--- a/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
@@ -53,7 +53,7 @@ object TaskCall {
 
 object CallNode {
 
-  final case class CallWithInputs(call: CallNode, inputs: Set[GraphInputNode]) {
+  final case class CallNodeAndNewInputs(call: CallNode, inputs: Set[GraphInputNode]) {
     def nodes: Set[GraphNode] = Set(call) ++ inputs
   }
 
@@ -73,7 +73,7 @@ object CallNode {
     * If an input is not supplied, it gets created as a GraphInputNode.
     *
     */
-  def callWithInputs(name: String, callable: Callable, portInputs: Map[String, OutputPort], expressionInputs: Set[GraphNodeInputExpression]): ErrorOr[CallWithInputs] = {
+  def callWithInputs(name: String, callable: Callable, portInputs: Map[String, OutputPort], expressionInputs: Set[GraphNodeInputExpression]): ErrorOr[CallNodeAndNewInputs] = {
 
     val graphNodeSetter = new GraphNode.GraphNodeSetter()
 
@@ -92,7 +92,7 @@ object CallNode {
       val callNode = CallNode(name, callable, linkedInputPorts, instantiatedExpressionInputs)
 
       graphNodeSetter._graphNode = callNode
-      CallWithInputs(callNode, graphInputNodes)
+      CallNodeAndNewInputs(callNode, graphInputNodes)
     }
   }
 }

--- a/wom/src/main/scala/wdl4s/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/Graph.scala
@@ -17,7 +17,8 @@ final case class Graph private(nodes: Set[GraphNode]) {
   // an explicit outputs block.  I'd remove this but the WDL/WOM test relies on it.
   def withDefaultOutputs: Graph = {
     val defaultOutputs: Set[GraphNode] = (nodes collect {
-      case callNode: CallNode => callNode.outputPorts.map(op => PortBasedGraphOutputNode(s"${callNode.name}.${op.name}", op.womType, op))
+      case node: CallNode => node.outputPorts.map(op => PortBasedGraphOutputNode(s"${node.name}.${op.name}", op.womType, op))
+      case node: ScatterNode => node.outputPorts.map(op => PortBasedGraphOutputNode(s"${op.name}", op.womType, op))
     }).flatten
     Graph(nodes.union(defaultOutputs))
   }

--- a/wom/src/main/scala/wdl4s/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/GraphInputNode.scala
@@ -15,3 +15,10 @@ sealed trait GraphInputNode extends GraphNode {
 final case class RequiredGraphInputNode(override val name: String, womType: WdlType) extends GraphInputNode
 final case class OptionalGraphInputNode(override val name: String, womType: WdlOptionalType) extends GraphInputNode
 final case class OptionalGraphInputNodeWithDefault(override val name: String, womType: WdlType, default: WomExpression) extends GraphInputNode
+
+/**
+  * Used to represent an input to any GraphNode's inner graph which is a link to a value somewhere in the outer graph.
+  */
+final case class OuterGraphInputNode(override val name: String, linkToOuterGraph: GraphNodePort.OutputPort) extends GraphInputNode {
+  override def womType: WdlType = linkToOuterGraph.womType
+}

--- a/wom/src/main/scala/wdl4s/wom/graph/GraphNodeInputExpression.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/GraphNodeInputExpression.scala
@@ -1,10 +1,18 @@
 package wdl4s.wom.graph
 
 import lenthall.validation.ErrorOr.ErrorOr
+import wdl4s.wdl.types.WdlType
 import wdl4s.wom.expression.WomExpression
 import wdl4s.wom.graph.GraphNode.GraphNodeSetter
 import wdl4s.wom.graph.GraphNodePort.OutputPort
 
+/**
+  * This is enough information for a GraphNode to build an InstantiatedExpression for an input.
+  * Differences:
+  * - This one remembers which input the expression is being assigned to.
+  * - InstantiatedExpression has created InputPorts for the expression inputs. This one only has references to OutputPorts
+  */
 case class GraphNodeInputExpression(inputName: String, expression: WomExpression, inputMapping: Map[String, OutputPort]) {
   private[graph] def instantiateExpression(graphNodeSetter: GraphNodeSetter): ErrorOr[(String, InstantiatedExpression)] = InstantiatedExpression.linkWithInputs(graphNodeSetter, expression, inputMapping) map { (inputName, _) }
+  private[graph] lazy val evaluateType: ErrorOr[WdlType] = expression.evaluateType(inputMapping.map { case (name, port) => (name, port.womType) })
 }

--- a/wom/src/main/scala/wdl4s/wom/graph/GraphOutputNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/GraphOutputNode.scala
@@ -15,7 +15,8 @@ sealed trait GraphOutputNode extends GraphNode {
   * Exposes an existing output port as a graph output.
   */
 final case class PortBasedGraphOutputNode(override val name: String, womType: WdlType, source: OutputPort) extends GraphOutputNode {
-  override val inputPorts: Set[GraphNodePort.InputPort] = Set(ConnectedInputPort(name, womType, source, _ => this))
+  val singleInputPort = ConnectedInputPort(name, womType, source, _ => this)
+  override val inputPorts: Set[GraphNodePort.InputPort] = Set(singleInputPort)
 }
 
 /**

--- a/wom/src/main/scala/wdl4s/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/ScatterNode.scala
@@ -1,13 +1,18 @@
 package wdl4s.wom.graph
 
-import wdl4s.wom.graph.GraphNodePort.{ConnectedInputPort, InputPort, OutputPort, ScatterGathererPort}
+import cats.data.Validated.Valid
+import cats.syntax.validated._
+import cats.syntax.apply._
+import lenthall.validation.ErrorOr.ErrorOr
+import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+import wdl4s.wom.graph.GraphNodePort.{InputPort, OutputPort, ScatterGathererPort}
 import wdl4s.wom.graph.ScatterNode.ScatterVariableMapping
-import wdl4s.wdl.types.WdlArrayType
+import wdl4s.wdl.types.{WdlArrayType, WdlMapType}
 import wdl4s.wom.graph.GraphNode.LinkedInputPort
 
 /**
   *
-  * @param graph Imagine that the contents of a WDL scatter block were a self-contained workflow. That's this Graph
+  * @param innerGraph Imagine that the contents of a WDL scatter block were a self-contained workflow. That's this Graph
   * @param scatterVariableMapping Case class representing:
   *                               - An (Array[X] type) InputPort to be exposed by the ScatterNode
   *                               - The (X type) GraphInputNode in the inner graph which it provides the input for
@@ -16,27 +21,28 @@ import wdl4s.wom.graph.GraphNode.LinkedInputPort
   *                        - NB It's 'other' because it doesn't include the scatter input variable.
   * @param outputMapping Output ports for the scatter node, which also link back to GraphOutputNodes of the inner graph.
   */
-final case class ScatterNode private(graph: Graph,
+final case class ScatterNode private(innerGraph: Graph,
                                      scatterVariableMapping: ScatterVariableMapping,
                                      otherInputPorts: Set[InputPort],
                                      outputMapping: Set[ScatterGathererPort]) extends GraphNode {
 
   override val name: String = "ScatterNode"
 
-  def innerGraphInputs: Set[GraphInputNode] = graph.nodes.collect { case gin: GraphInputNode => gin }
+  def innerGraphInputs: Set[GraphInputNode] = innerGraph.nodes.collect { case gin: GraphInputNode => gin }
 
   // NB if you find yourself calling .filter on this set of inputPorts, you probably just wanted to access either
   // the scatterVariableMapping or otherInputPorts fields directly.
-  override val inputPorts: Set[InputPort] = Set(scatterVariableMapping.inputPort) ++ otherInputPorts
+  override val inputPorts: Set[InputPort] = scatterVariableMapping.scatterInstantiatedExpression.inputPorts ++ otherInputPorts
   override val outputPorts: Set[GraphNodePort.OutputPort] = outputMapping.toSet[OutputPort]
 }
 
 object ScatterNode {
 
   /**
-    * Maps from an InputPort on the ScatterNode to the GraphInputNode in the innerGraph
+    * Maps from an InstantiatedExpression on the ScatterNode to the GraphInputNode in the innerGraph.
+    * A 'None' for graphInputNode indicates that the inner graph doesn't use the scatter variable.
     */
-  case class ScatterVariableMapping(inputPort: InputPort, graphInputNode: GraphInputNode)
+  case class ScatterVariableMapping(scatterInstantiatedExpression: InstantiatedExpression, graphInputNode: GraphInputNode)
 
   final case class ScatterNodeWithInputs(scatter: ScatterNode, inputs: Set[GraphInputNode])
 
@@ -50,14 +56,22 @@ object ScatterNode {
     *         * scatter: The scatter node itself, connected to the inputs
     *         * inputs: A set of GraphInputNodes for inputs which weren't supplied
     */
-  // TODO: Validate that the scatter source is an array type (oh how I wish ports could be typed!)
-  def scatterOverGraph(innerGraph: Graph, scatterVariableSource: OutputPort, scatterVariableInput: GraphInputNode, inputMapping: Map[String, OutputPort]): ScatterNodeWithInputs = {
+  // TODO: For CWL, we'll probably want the 'scatterVariableSource' to be an expression OR a GraphNodePort.OutputPort. TBC...
+  def scatterOverGraph(innerGraph: Graph, scatterVariableSource: GraphNodeInputExpression, scatterVariableInput: GraphInputNode, inputMapping: Map[String, OutputPort]): ErrorOr[ScatterNodeWithInputs] = {
     val graphNodeSetter = new GraphNode.GraphNodeSetter()
     val inputPortLinker = GraphNode.linkInputPort("", inputMapping, graphNodeSetter.get) _
 
-    val scatterVariableMapping = ScatterVariableMapping(ConnectedInputPort(scatterVariableInput.name, scatterVariableInput.womType, scatterVariableSource, graphNodeSetter.get), scatterVariableInput)
+    val scatterExpressionType: ErrorOr[WdlArrayType] = scatterVariableSource.evaluateType flatMap {
+      case arrayType: WdlArrayType => Valid(arrayType)
+      case mapType: WdlMapType => Valid(mapType.equivalentArrayType)
+      case other => s"Cannot scatter over non-array type ${other.toWdlString}".invalidNel
+    }
 
-    // TODO: Don't want to re-link the scatter variable...
+    val scatterVariableMappingValidation: ErrorOr[ScatterVariableMapping] = scatterVariableSource.instantiateExpression(graphNodeSetter) map {
+      case (_, scatterInstantiatedExpression) => ScatterVariableMapping(scatterInstantiatedExpression, scatterVariableInput)
+    }
+
+    // Filter because we don't want to re-link the scatter variable...
     val linkedInputPortsAndGraphInputNodes: Set[LinkedInputPort] = (innerGraph.nodes - scatterVariableInput).inputDefinitions.map(inputPortLinker)
     val linkedInputPorts = linkedInputPortsAndGraphInputNodes.map(_.newInputPort)
     val graphInputNodes = linkedInputPortsAndGraphInputNodes collect { case LinkedInputPort(_, Some(gin)) => gin }
@@ -66,9 +80,11 @@ object ScatterNode {
       ScatterGathererPort(gon.name, WdlArrayType(gon.womType), gon, graphNodeSetter.get)
     }
 
-    val scatterNode: ScatterNode = ScatterNode(innerGraph, scatterVariableMapping, linkedInputPorts, outputPorts)
-    graphNodeSetter._graphNode = scatterNode
+    (scatterVariableMappingValidation, scatterExpressionType) mapN { (scatterVariableMapping, _) =>
+      val scatterNode: ScatterNode = ScatterNode(innerGraph, scatterVariableMapping, linkedInputPorts, outputPorts)
+      graphNodeSetter._graphNode = scatterNode
 
-    ScatterNodeWithInputs(scatterNode, graphInputNodes)
+      ScatterNodeWithInputs(scatterNode, graphInputNodes)
+    }
   }
 }

--- a/wom/src/test/scala/wdl4s/wdl/wom/WdlScatterWomSpec.scala
+++ b/wom/src/test/scala/wdl4s/wdl/wom/WdlScatterWomSpec.scala
@@ -1,0 +1,202 @@
+package wdl4s.wdl.wom
+
+import lenthall.collections.EnhancedCollections._
+import cats.data.Validated.{Invalid, Valid}
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.wdl.types.{WdlArrayType, WdlIntegerType, WdlStringType}
+import wdl4s.wdl.{WdlNamespace, WdlNamespaceWithWorkflow}
+import wdl4s.wom.graph.GraphNodePort.ScatterGathererPort
+import wdl4s.wom.graph.{GraphInputNode, ScatterNode, _}
+
+class WdlScatterWomSpec extends FlatSpec with Matchers {
+
+  behavior of "WdlNamespaces with scatters"
+
+  it should "convert gathered scatter outputs to workflow outputs" in {
+    val scatterTest =
+      """task foo {
+        |  Int i
+        |  command { ... }
+        |  output {
+        |    String out = i
+        |  }
+        |}
+        |
+        |workflow scatter_test {
+        |  Array[Int] xs
+        |  scatter (x in xs) {
+        |    call foo { input: i = x }
+        |  }
+        |}""".stripMargin
+
+    val namespace = WdlNamespace.loadUsingSource(scatterTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    val scatterTestGraph = namespace.womExecutable.flatMap(_.graph)
+
+    scatterTestGraph match {
+      case Valid(g) => validateGraph(g)
+      case Invalid(errors) => fail(s"Unable to build wom version of scatter foo from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
+    }
+
+    def validateGraph(workflowGraph: Graph) = {
+
+      case class OuterGraphValidations(scatterNode: ScatterNode, xs_inputNode: GraphInputNode)
+      def validateOuterGraph: OuterGraphValidations = {
+        val scatterNode = workflowGraph.nodes.firstByType[ScatterNode].getOrElse(fail("Resulting graph did not contain a ScatterNode"))
+
+        val xs_inputNode = workflowGraph.nodes.collectFirst {
+          case gin: GraphInputNode if gin.name == "xs" => gin
+        }.getOrElse(fail("Resulting graph did not contain the 'xs' GraphInputNode"))
+
+        val foo_out_output = workflowGraph.nodes.collectFirst {
+          case gon: GraphOutputNode if gon.name == "foo.out" => gon
+        }.getOrElse(fail("Resulting graph did not contain the 'foo.out' GraphOutputNode"))
+        foo_out_output.womType should be(WdlArrayType(WdlStringType))
+
+        workflowGraph.nodes should be(Set(scatterNode, xs_inputNode, foo_out_output))
+        OuterGraphValidations(scatterNode, xs_inputNode)
+      }
+
+      case class InnerGraphValidations(x_scatterCollectionInput: GraphInputNode, foo_out_innerOutput: GraphOutputNode)
+      def validateInnerGraph(validatedOuterGraph: OuterGraphValidations): InnerGraphValidations = {
+        val x_scatterCollectionInput = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
+          case gin: GraphInputNode if gin.name == "x" => gin
+        }.getOrElse(fail("Scatter inner graph did not contain a GraphInputNode 'x'"))
+
+        val foo_callNode = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
+          case c: TaskCallNode if c.name == "foo" => c
+        }.getOrElse(fail("Scatter inner graph did not contain a call to 'foo'"))
+
+        val foo_out_innerOutput = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
+          case gon: GraphOutputNode if gon.name == "foo.out" => gon
+        }.getOrElse(fail("Scatter inner graph did not contain a GraphOutputNode 'foo.out'"))
+
+        validatedOuterGraph.scatterNode.innerGraph.nodes should be(Set(x_scatterCollectionInput, foo_callNode, foo_out_innerOutput))
+        InnerGraphValidations(x_scatterCollectionInput, foo_out_innerOutput)
+      }
+
+      def validateConnections(validatedOuterGraph: OuterGraphValidations, validatedInnerGraph: InnerGraphValidations) = {
+        // The scatter collection links to its predecessor
+        validatedOuterGraph.scatterNode.scatterVariableMapping.scatterInstantiatedExpression.inputPorts.map(_.upstream.graphNode) should be(Set(validatedOuterGraph.xs_inputNode))
+
+        // The ScatterNode's "scatter variable mapping" links to the innerGraph's scatter variable input Node:
+        validatedOuterGraph.scatterNode.scatterVariableMapping.graphInputNode eq validatedInnerGraph.x_scatterCollectionInput should be(true)
+
+        // The ScatterNode's output port links to the inner graph's GraphOutputNode:
+        validatedOuterGraph.scatterNode.outputMapping.toList match {
+          case ScatterGathererPort(name, womType, outputToGather, _) :: Nil =>
+            name should be("foo.out")
+            womType should be(WdlArrayType(WdlStringType))
+            outputToGather eq validatedInnerGraph.foo_out_innerOutput should be(true)
+          case other => fail("Expected exactly one output to be gathered in this scatter but got:" + other.mkString("\n", "\n", "\n"))
+        }
+      }
+
+      val outer = validateOuterGraph
+      val inner = validateInnerGraph(outer)
+      validateConnections(outer, inner)
+    }
+  }
+
+  it should "convert inputs into inner graph inputs" in {
+    val scatterTest =
+      """task foo {
+        |  Int i
+        |  command { ... }
+        |  output {
+        |    String str_out = i
+        |    Int int_out = i + 1
+        |  }
+        |}
+        |
+        |workflow scatter_test {
+        |  Int x = 5
+        |  Int y = 6
+        |  Int z = 7
+        |  scatter (s in [x, y]) {
+        |    call foo { input: i = z }
+        |  }
+        |}""".stripMargin
+
+    val namespace = WdlNamespace.loadUsingSource(scatterTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    val scatterTestGraph = namespace.womExecutable.flatMap(_.graph)
+
+    scatterTestGraph match {
+      case Valid(g) => validateGraph(g)
+      case Invalid(errors) => fail(s"Unable to build wom version of scatter foo from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
+    }
+
+    def validateGraph(workflowGraph: Graph) = {
+
+      // Three inputs, a scatter node and two outputs:
+      workflowGraph.nodes.size should be(6)
+
+      // Find that scatter:
+      workflowGraph.nodes.collectFirst {
+        case s: ScatterNode => s
+      }.getOrElse(fail("Resulting graph did not contain a ScatterNode"))
+
+
+    }
+  }
+
+  it should "convert unsatisfied call inputs in scatters into outer graph inputs" in {
+    val scatterTest =
+      """task foo {
+        |  Int i
+        |  Int j
+        |  command { ... }
+        |  output {
+        |    String str_out = i
+        |    Int int_out = i + 1
+        |  }
+        |}
+        |
+        |workflow scatter_test {
+        |  Int x = 5
+        |  scatter (s in range(x)) {
+        |    call foo { input: i = s } # nb: foo.j is missing!
+        |  }
+        |
+        |  Array[String] str_outs = foo.str_out
+        |}
+        |""".stripMargin
+
+    val namespace = WdlNamespace.loadUsingSource(scatterTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    val scatterTestGraph = namespace.womExecutable.flatMap(_.graph)
+
+    scatterTestGraph match {
+      case Valid(g) => validateGraph(g)
+      case Invalid(errors) => fail(s"Unable to build wom version of scatter foo from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
+    }
+
+    def validateGraph(workflowGraph: Graph) = {
+
+      // Find the inputs:
+      val inputNodes: Set[GraphInputNode] = workflowGraph.nodes.filterByType[GraphInputNode]
+      inputNodes.map {_.name} should be(Set("x", "foo.j"))
+
+      // Find that scatter:
+      val scatterNode = workflowGraph.nodes.collectFirst {
+        case s: ScatterNode => s
+      }.getOrElse(fail("Resulting graph did not contain a ScatterNode"))
+
+      val scatterInnerInputs: Set[GraphInputNode] = scatterNode.innerGraph.nodes.filterByType[GraphInputNode]
+      scatterInnerInputs map {_.name} should be(Set("s", "foo.j"))
+      (scatterInnerInputs.find(_.name == "foo.j").get, inputNodes.find(_.name == "foo.j").get) match {
+        case (fooj1, fooj2) if fooj1 eq fooj2 => fail("Scatter has used the inner graph input Node as an outer graph input")
+        case _ => // fine
+      }
+
+      // Find the outputs:
+      val outputNodes = workflowGraph.nodes.collect {
+        case output: GraphOutputNode => output
+      }
+      outputNodes map { on => (on.name, on.womType) } should be(Set(("foo.int_out", WdlArrayType(WdlIntegerType)), ("foo.str_out", WdlArrayType(WdlStringType))))
+
+    }
+  }
+
+}

--- a/wom/src/test/scala/wdl4s/wom/graph/ExpressionAsCallInputSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/ExpressionAsCallInputSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import wdl4s.wdl.types.WdlIntegerType
 import wdl4s.wom.callable.TaskDefinitionSpec
 import wdl4s.wom.expression._
-import wdl4s.wom.graph.CallNode.CallWithInputs
+import wdl4s.wom.graph.CallNode.CallNodeAndNewInputs
 
 class ExpressionAsCallInputSpec extends FlatSpec with Matchers {
 
@@ -33,7 +33,7 @@ class ExpressionAsCallInputSpec extends FlatSpec with Matchers {
     // Declare an expression that needs both an "i" and a "j":
     val ijExpression = PlaceholderWomExpression(Set("i", "j"), WdlIntegerType)
 
-    def validateCallResult(callWithInputs: CallWithInputs) = {
+    def validateCallResult(callWithInputs: CallNodeAndNewInputs) = {
       callWithInputs.inputs should be(Set.empty)
       callWithInputs.call.upstream should be(Set(iInputNode, jInputNode))
     }

--- a/wom/src/test/scala/wdl4s/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/GraphSpec.scala
@@ -6,7 +6,7 @@ import wdl4s.wdl.RuntimeAttributes
 import wdl4s.wdl.types.{WdlFileType, WdlIntegerType, WdlStringType}
 import wdl4s.wom.callable.Callable.{OutputDefinition, RequiredInputDefinition}
 import wdl4s.wom.callable.{TaskDefinition, WorkflowDefinition}
-import wdl4s.wom.graph.CallNode.CallWithInputs
+import wdl4s.wom.graph.CallNode.CallNodeAndNewInputs
 
 class GraphSpec extends FlatSpec with Matchers {
   behavior of "Graph"
@@ -45,11 +45,11 @@ class GraphSpec extends FlatSpec with Matchers {
       declarations = List.empty
     )
 
-    val CallWithInputs(psCall, psGraphInputs) = CallNode.callWithInputs("ps", taskDefinition_ps, Map.empty, Set.empty).getOrElse(fail("Unable to call ps"))
+    val CallNodeAndNewInputs(psCall, psGraphInputs) = CallNode.callWithInputs("ps", taskDefinition_ps, Map.empty, Set.empty).getOrElse(fail("Unable to call ps"))
     val ps_procsOutputPort = psCall.outputByName("procs").getOrElse(fail("Unexpectedly unable to find 'procs' output"))
 
-    val CallWithInputs(cgrepCall, cgrepGraphInputs) = CallNode.callWithInputs("cgrep", taskDefinition_cgrep, Map("in_file" -> ps_procsOutputPort), Set.empty).getOrElse(fail("Unable to call cgrep"))
-    val CallWithInputs(wcCall, wcGraphInputs) = CallNode.callWithInputs("wc", taskDefinition_wc, Map("in_file" -> ps_procsOutputPort), Set.empty).getOrElse(fail("Unable to call wc"))
+    val CallNodeAndNewInputs(cgrepCall, cgrepGraphInputs) = CallNode.callWithInputs("cgrep", taskDefinition_cgrep, Map("in_file" -> ps_procsOutputPort), Set.empty).getOrElse(fail("Unable to call cgrep"))
+    val CallNodeAndNewInputs(wcCall, wcGraphInputs) = CallNode.callWithInputs("wc", taskDefinition_wc, Map("in_file" -> ps_procsOutputPort), Set.empty).getOrElse(fail("Unable to call wc"))
 
     val graphNodes: Set[GraphNode] =
       Set[GraphNode](psCall, cgrepCall, wcCall)
@@ -73,7 +73,7 @@ class GraphSpec extends FlatSpec with Matchers {
 
   it should "be able to represent calls to sub-workflows" in {
     val threeStepWorkflow = WorkflowDefinition("three_step", makeThreeStep, Map.empty, Map.empty, List.empty)
-    val CallWithInputs(threeStepCall, threeStepInputs) = CallNode.callWithInputs("three_step", threeStepWorkflow, Map.empty, Set.empty).getOrElse(fail("Unable to call three_step"))
+    val CallNodeAndNewInputs(threeStepCall, threeStepInputs) = CallNode.callWithInputs("three_step", threeStepWorkflow, Map.empty, Set.empty).getOrElse(fail("Unable to call three_step"))
 
     val workflowGraph = Graph.validateAndConstruct(Set[GraphNode](threeStepCall).union(threeStepInputs.toSet[GraphNode])) match {
       case Valid(wg) => wg.withDefaultOutputs

--- a/wom/src/test/scala/wdl4s/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wdl4s/wom/graph/ScatterNodeSpec.scala
@@ -1,6 +1,7 @@
 package wdl4s.wom.graph
 
 import cats.data.Validated.{Invalid, Valid}
+import cats.syntax.apply._
 import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
 import org.scalatest.{FlatSpec, Matchers}
 import wdl4s.wdl.RuntimeAttributes
@@ -8,7 +9,7 @@ import wdl4s.wdl.types.{WdlArrayType, WdlIntegerType, WdlStringType}
 import wdl4s.wom.callable.Callable.{OutputDefinition, RequiredInputDefinition}
 import wdl4s.wom.callable.TaskDefinition
 import wdl4s.wom.expression.PlaceholderWomExpression
-import wdl4s.wom.graph.CallNode.CallWithInputs
+import wdl4s.wom.graph.CallNode.CallNodeAndNewInputs
 import wdl4s.wom.graph.ScatterNode.ScatterNodeWithInputs
 
 class ScatterNodeSpec extends FlatSpec with Matchers {
@@ -49,52 +50,56 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
     val xs_inputNode = RequiredGraphInputNode("xs", WdlArrayType(WdlIntegerType))
 
     val x_inputNode = RequiredGraphInputNode("x", WdlIntegerType)
-    val CallWithInputs(foo_callNode, _) = CallNode.callWithInputs("foo", task_foo, Map("i" -> x_inputNode.singleOutputPort), Set.empty).getOrElse(fail("Unable to call foo_callNode"))
+    val CallNodeAndNewInputs(foo_callNode, _) = CallNode.callWithInputs("foo", task_foo, Map("i" -> x_inputNode.singleOutputPort), Set.empty).getOrElse(fail("Unable to call foo_callNode"))
     val scatterGraph = Graph.validateAndConstruct(Set(foo_callNode, x_inputNode)) match {
       case Valid(sg) => sg.withDefaultOutputs
       case Invalid(es) => fail("Failed to make scatter graph: " + es.toList.mkString(", "))
     }
 
-    val ScatterNodeWithInputs(scatterNode, unsuppliedScatterInputNodes) = ScatterNode.scatterOverGraph(scatterGraph, xs_inputNode.singleOutputPort, x_inputNode, Map.empty)
-    unsuppliedScatterInputNodes.size should be(0)
+    val xsExpression = PlaceholderWomExpression(Set("xs"), WdlArrayType(WdlIntegerType))
+    val xsExpressionAsInput = GraphNodeInputExpression("x", xsExpression, Map("xs" -> xs_inputNode.singleOutputPort))
+
+    val scatterNodeValidation = ScatterNode.scatterOverGraph(scatterGraph, xsExpressionAsInput, x_inputNode, Map.empty)
 
     val workflowGraphValidation = for {
+      scatterNodeWithInputs <- scatterNodeValidation
+      ScatterNodeWithInputs(scatterNode, unsuppliedScatterInputNodes) = scatterNodeWithInputs
+
+      _ = unsuppliedScatterInputNodes.size should be(0)
       foo_scatterOutput <- scatterNode.outputByName("foo.out")
       z_workflowOutput = PortBasedGraphOutputNode("z", WdlArrayType(WdlStringType), foo_scatterOutput)
       graph <- Graph.validateAndConstruct(Set(scatterNode, xs_inputNode, z_workflowOutput))
     } yield graph
 
-    val workflowGraph = workflowGraphValidation match {
-      case Valid(wg) => wg
+    (workflowGraphValidation, scatterNodeValidation).tupled match {
+      case Valid((wg, sn)) => validate(wg, sn.scatter)
       case Invalid(es) => fail("Failed to make workflow graph: " + es.toList.mkString(", "))
     }
 
-    //
-    // Above: Tests that we can create the scatter
-    // Below: Tests that it was made right!
-    //
+    /**
+      * WDL -> WOM conversion has succeeded, now let's check we built it right!
+      */
+    def validate(workflowGraph: Graph, scatterNode: ScatterNode) = {
+      workflowGraph.nodes collect { case gin: GraphInputNode => gin.name } should be(Set("xs"))
+      workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.name } should be(Set("z"))
+      workflowGraph.nodes collect { case cn: CallNode => cn.name } should be(Set.empty)
+      (workflowGraph.nodes collect { case sn: ScatterNode => sn }).size should be(1)
 
+      // The output links back to the scatter:
+      val finalOutput = (workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon }).head
+      finalOutput.upstream should be(Set(scatterNode))
 
-    workflowGraph.nodes collect { case gin: GraphInputNode => gin.name } should be(Set("xs"))
-    workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.name } should be(Set("z"))
-    workflowGraph.nodes collect { case cn: CallNode => cn.name } should be(Set.empty)
-    (workflowGraph.nodes collect { case sn: ScatterNode => sn }).size should be(1)
+      // The scatter output port is called foo.out:
+      finalOutput.inputPorts.head.upstream.name should be("foo.out")
 
-    // The output links back to the scatter:
-    val finalOutput = (workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon }).head
-    finalOutput.upstream should be(Set(scatterNode))
-
-    // The scatter output port is called foo.out:
-    finalOutput.inputPorts.head.upstream.name should be("foo.out")
-
-    // foo.out links back to the correct output in the inner graph:
-    val innerGraphFooOutNode = scatterNode.outputMapping.find(_.name == "foo.out").getOrElse(fail("Scatter couldn't link back the foo.out output.")).outputToGather
-    innerGraphFooOutNode.womType should be(WdlStringType)
-    innerGraphFooOutNode.upstream.size should be(1)
-    innerGraphFooOutNode.upstream.head match {
-      case c: CallNode => c.name should be("foo")
-      case _ => fail("Expected the inner graph to have a Call Node!")
+      // foo.out links back to the correct output in the inner graph:
+      val innerGraphFooOutNode = scatterNode.outputMapping.find(_.name == "foo.out").getOrElse(fail("Scatter couldn't link back the foo.out output.")).outputToGather
+      innerGraphFooOutNode.womType should be(WdlStringType)
+      innerGraphFooOutNode.upstream.size should be(1)
+      innerGraphFooOutNode.upstream.head match {
+        case c: CallNode => c.name should be("foo")
+        case _ => fail("Expected the inner graph to have a Call Node!")
+      }
     }
-
   }
 }


### PR DESCRIPTION
Includes a change of `WDL -> WOM` conversion strategy from "generate in place" to "fold over a sorted list". Demonstration conversion follows.

Scatter in a WDL:
```
task foo {
  Int i
  command { ... }
  output {
    Int int_out = i + 1
  }
}

workflow scatter_test {
  Int a = 5
  Int b = a
  scatter (s in range(b)) {
    call foo { input: i = s + a }
  }
  Array[Int] xs = foo.int_out
  Array[Int] ys = xs
}
```
And as a WOM diagram:
![test](https://user-images.githubusercontent.com/13006282/29883866-9798674a-8d7f-11e7-87f8-e90458113d1f.png)

