### PR TITLE
properly recognizing existing required graph inputs

### DIFF
--- a/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
@@ -69,7 +69,7 @@ case class Workflow(
     val graphFromSteps =
       steps.
         toList.
-        foldLeft(Set.empty[GraphNode])(
+        foldLeft(Set.empty[GraphNode] ++ graphFromInputs)(
           (nodes, step) => step.callWithInputs(typeMap,  this, nodes, workflowInputs))
 
     val graphFromOutputs: ErrorOr[Set[GraphNode]] =

--- a/cwl/src/test/scala/wdl4s/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/wdl4s/cwl/CwlWorkflowWomSpec.scala
@@ -53,7 +53,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers {
     } yield validateWom(wom)).leftMap(e => throw new RuntimeException(s"error! $e"))
   }
 
-  "Cwl for 1st workflow" should "convert to WOM" ignore {
+  "Cwl for 1st workflow" should "convert to WOM" in {
     (for {
       wf <- decodeAllCwl(rootPath/"1st-workflow.cwl").
               value.
@@ -96,7 +96,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers {
     }
   }
 
-  "A WdlNamespace for 3step" should "provide conversion to WOM" ignore {
+  "A WdlNamespace for 3step" should "provide conversion to WOM" in {
 
     val wf = decodeAllCwl(rootPath/"three_step.cwl").map {
       _.select[Workflow].get


### PR DESCRIPTION
does solve tests passing.

does not solve `getOrElse` part of ungrossify ticket