### PR TITLE
Fix WDL -> WOM aliased calls (alii? aliumnibuses?)

### DIFF
--- a/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wdl4s/wom/graph/CallNode.scala
@@ -82,7 +82,7 @@ object CallNode {
     val instantiatedExpressionInputsAttempt: ErrorOr[Map[String, InstantiatedExpression]] = expressionInputs.toList traverse { _.instantiateExpressionWithInputName(graphNodeSetter) } map { _.toMap }
 
     instantiatedExpressionInputsAttempt map { instantiatedExpressionInputs =>
-      val inputPortLinker = GraphNode.linkInputPort(callable.name + prefixSeparator, portInputs, graphNodeSetter.get) _
+      val inputPortLinker = GraphNode.linkInputPort(name + prefixSeparator, portInputs, graphNodeSetter.get) _
 
       // Filter out the inputs we already have from expressions:
       val asYetUnsuppliedInputs = callable.inputs.filterNot(inputDef => instantiatedExpressionInputs.contains(inputDef.name))

--- a/wom/src/test/scala/wdl4s/wdl/wom/WdlAliasWomSpec.scala
+++ b/wom/src/test/scala/wdl4s/wdl/wom/WdlAliasWomSpec.scala
@@ -1,0 +1,51 @@
+package wdl4s.wdl.wom
+
+import cats.data.Validated.{Invalid, Valid}
+import lenthall.collections.EnhancedCollections._
+import org.scalatest.{FlatSpec, Matchers}
+import wdl4s.wdl.{WdlNamespace, WdlNamespaceWithWorkflow}
+import wdl4s.wom.graph._
+
+class WdlAliasWomSpec extends FlatSpec with Matchers {
+
+  behavior of "WdlNamespaces with aliased calls"
+
+  it should "get successfully converted into WOM" in {
+    val conditionalTest =
+      """task foo {
+        |  Int i
+        |  command { ... }
+        |  output {
+        |    String out = i
+        |  }
+        |}
+        |
+        |workflow conditional_test {
+        |  call foo as foo1
+        |  call foo as foo2
+        |}""".stripMargin
+
+    val namespace = WdlNamespace.loadUsingSource(conditionalTest, None, None).get.asInstanceOf[WdlNamespaceWithWorkflow]
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    val conditionalTestGraph = namespace.womExecutable.flatMap(_.graph)
+
+    conditionalTestGraph match {
+      case Valid(g) => validateGraph(g)
+      case Invalid(errors) => fail(s"Unable to build wom version of conditional foo from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
+    }
+
+    def validateGraph(workflowGraph: Graph) = {
+
+      val inputNodes: Set[GraphInputNode] = workflowGraph.nodes.filterByType[GraphInputNode]
+      inputNodes.map(_.name) should be(Set("foo1.i", "foo2.i"))
+
+      val callNodes: Set[CallNode] = workflowGraph.nodes.filterByType[CallNode]
+      callNodes.map(_.name) should be(Set("foo1", "foo2"))
+
+      val outputNodes: Set[GraphOutputNode] = workflowGraph.nodes.filterByType[GraphOutputNode]
+      outputNodes.map(_.name) should be(Set("foo1.out", "foo2.out"))
+
+      workflowGraph.nodes.size should be(6)
+    }
+  }
+}


### PR DESCRIPTION
This was a small problem where inputs nodes were being created based on task name rather than call name.