### PR TITLE
Witness types in Cwl constructors

### DIFF
--- a/cwl/src/main/scala/wdl4s/cwl/CwlCodecs.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/CwlCodecs.scala
@@ -32,12 +32,4 @@ object CwlCodecs {
 
   def encodeCwl(cwl: Cwl): Json = cwl.fold(CwlEncoder)
 
-  val jsonPrettyPrinter = io.circe.Printer.spaces2.copy(dropNullKeys = true, preserveOrder = true)
-
-  val yamlPrettyPrinter = io.circe.yaml.Printer.spaces2.copy(dropNullKeys = true, preserveOrder = true)
-
-  def cwlToJson(cwl: Cwl): String = jsonPrettyPrinter.pretty(encodeCwl(cwl))
-
-  def cwlToYaml(cwl: Cwl): String = yamlPrettyPrinter.pretty(encodeCwl(cwl))
-
 }

--- a/cwl/src/main/scala/wdl4s/cwl/CwlCodecs.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/CwlCodecs.scala
@@ -32,4 +32,7 @@ object CwlCodecs {
 
   def encodeCwl(cwl: Cwl): Json = cwl.fold(CwlEncoder)
 
+  val jsonPrettyPrinter = io.circe.Printer.spaces2.copy(dropNullValues = true, preserveOrder = true)
+
+  def cwlToJson(cwl: Cwl): String = jsonPrettyPrinter.pretty(encodeCwl(cwl))
 }

--- a/cwl/src/main/scala/wdl4s/cwl/CwlFile.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/CwlFile.scala
@@ -33,28 +33,28 @@ import wdl4s.wom.{CommandPart, RuntimeAttributes}
   * @param temporaryFailCodes
   * @param permanentFailCodes
   */
-case class CommandLineTool(
-                            inputs: Array[CommandInputParameter] = Array.empty,
-                            outputs: Array[CommandOutputParameter] = Array.empty,
-                            `class`: Witness.`"CommandLineTool"`.T = "CommandLineTool".narrow,
-                            id: Option[String] = None,
-                            requirements: Option[Array[Requirement]] = None,
+case class CommandLineTool private(
+                                   inputs: Array[CommandInputParameter],
+                                   outputs: Array[CommandOutputParameter],
+                                   `class`: Witness.`"CommandLineTool"`.T,
+                                   id: Option[String],
+                                   requirements: Option[Array[Requirement]],
 
-                            //TODO: Fix this when CwlAny parses correctly
-                            //hints: Option[Array[CwlAny]] = None,
-                            hints: Option[Array[Map[String, String]]] = None,
+                                   //TODO: Fix this when CwlAny parses correctly
+                                   //hints: Option[Array[CwlAny]] = None,
+                                   hints: Option[Array[Map[String, String]]],
 
-                            label: Option[String] = None,
-                            doc: Option[String] = None,
-                            cwlVersion: Option[CwlVersion] = Option(CwlVersion.Version1),
-                            baseCommand: Option[BaseCommand] = None,
-                            arguments: Option[Array[CommandLineTool.Argument]] = None,
-                            stdin: Option[StringOrExpression] = None,
-                            stderr: Option[StringOrExpression] = None,
-                            stdout: Option[StringOrExpression] = None,
-                            successCodes: Option[Array[Int]] = None,
-                            temporaryFailCodes: Option[Array[Int]] = None,
-                            permanentFailCodes: Option[Array[Int]] = None) {
+                                   label: Option[String],
+                                   doc: Option[String],
+                                   cwlVersion: Option[CwlVersion],
+                                   baseCommand: Option[BaseCommand],
+                                   arguments: Option[Array[CommandLineTool.Argument]],
+                                   stdin: Option[StringOrExpression],
+                                   stderr: Option[StringOrExpression],
+                                   stdout: Option[StringOrExpression],
+                                   successCodes: Option[Array[Int]],
+                                   temporaryFailCodes: Option[Array[Int]],
+                                   permanentFailCodes: Option[Array[Int]]) {
 
   def womExecutable: ErrorOr[Executable] =
     Valid(Executable(taskDefinition))
@@ -139,6 +139,25 @@ case class CommandLineTool(
 }
 
 object CommandLineTool {
+
+  def apply(inputs: Array[CommandInputParameter] = Array.empty,
+            outputs: Array[CommandOutputParameter] = Array.empty,
+            id: Option[String] = None,
+            requirements: Option[Array[Requirement]] = None,
+            hints: Option[Array[Map[String, String]]] = None,
+            label: Option[String] = None,
+            doc: Option[String] = None,
+            cwlVersion: Option[CwlVersion] = Option(CwlVersion.Version1),
+            baseCommand: Option[BaseCommand] = None,
+            arguments: Option[Array[CommandLineTool.Argument]] = None,
+            stdin: Option[StringOrExpression] = None,
+            stderr: Option[StringOrExpression] = None,
+            stdout: Option[StringOrExpression] = None,
+            successCodes: Option[Array[Int]] = None,
+            temporaryFailCodes: Option[Array[Int]] = None,
+            permanentFailCodes: Option[Array[Int]] = None): CommandLineTool  =
+              CommandLineTool(inputs, outputs, "CommandLineTool".narrow, id, requirements, hints, label, doc, cwlVersion, baseCommand, arguments, stdin, stderr, stdout, successCodes, temporaryFailCodes, permanentFailCodes)
+
 
   type StringOrExpression = ECMAScriptExpression :+: String :+: CNil
 

--- a/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
@@ -4,6 +4,11 @@ import cats.data.Validated._
 import cats.instances.list._
 import cats.syntax.option._
 import cats.syntax.traverse._
+import CwlType._
+import shapeless._
+import shapeless.syntax.singleton._
+import CwlVersion._
+import cats.data.Validated._
 import lenthall.validation.ErrorOr._
 import shapeless._
 import wdl4s.cwl.CwlType.CwlType
@@ -15,11 +20,11 @@ import wdl4s.wom.expression.WomExpression
 import wdl4s.wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 import wdl4s.wom.graph._
 
-case class Workflow(
-                     cwlVersion: Option[CwlVersion] = Option(CwlVersion.Version1),
-                     `class`: Workflow.ClassType = Workflow.`class`,
-                     inputs: Array[InputParameter] = Array.empty,
-                     outputs: Array[WorkflowOutputParameter] = Array.empty,
+case class Workflow private(
+                     cwlVersion: Option[CwlVersion],
+                     `class`: Witness.`"Workflow"`.T,
+                     inputs: Array[InputParameter],
+                     outputs: Array[WorkflowOutputParameter],
                      steps: Array[WorkflowStep]) {
 
   def womExecutable: ErrorOr[Executable] = womDefinition map Executable.apply
@@ -110,7 +115,9 @@ case class Workflow(
 }
 object Workflow {
 
-  type ClassType = Witness.`"Workflow"`.T
-
-  val `class`: ClassType = "Workflow".asInstanceOf[ClassType]
+  def apply(cwlVersion: Option[CwlVersion] = Option(CwlVersion.Version1),
+            inputs: Array[InputParameter] = Array.empty,
+            outputs: Array[WorkflowOutputParameter] = Array.empty,
+            steps: Array[WorkflowStep] = Array.empty): Workflow  =
+              Workflow(cwlVersion, "Workflow".narrow, inputs, outputs, steps)
 }

--- a/cwl/src/test/scala/wdl4s/cwl/ExportCwlSamplesSpec.scala
+++ b/cwl/src/test/scala/wdl4s/cwl/ExportCwlSamplesSpec.scala
@@ -2,17 +2,17 @@ package wdl4s.cwl
 
 import org.scalatest.{FlatSpec, Matchers}
 import shapeless.Coproduct
-import shapeless.syntax.singleton._
 import wdl4s.cwl.CommandLineTool.{BaseCommand, StringOrExpression}
 import wdl4s.cwl.WorkflowStepInput.InputSource
 
 class ExportCwlSamplesSpec extends FlatSpec with Matchers {
-  def assertCorrectJson(cwl: Cwl, expectedYaml: String) = CwlCodecs.cwlToYaml(cwl) shouldBe expectedYaml
+  //TODO: Re-implement ability to write CWL to Yaml
+  //(DB)Ability to write JSON removed due to conflicting circe-yaml cats dependency
+  def assertCorrectJson(cwl: Cwl, expectedYaml: String) = ??? // ??? shouldBe expectedYaml
 
-  it should "encode sample CWL command line tool" in {
+  it should "encode sample CWL command line tool" ignore {
     val tool =
       CommandLineTool(
-        `class` = "CommandLineTool".narrow,
         inputs =  Array(CommandInputParameter(
           id = "message",
           inputBinding = Option(CommandLineBinding(
@@ -34,7 +34,7 @@ baseCommand: echo
     assertCorrectJson(tool.asCwl, expectedToolJsonString)
   }
 
-  it should "encode sample CWL workflow" in {
+  it should "encode sample CWL workflow" ignore {
     val workflow = Workflow(
       inputs = Array(
           InputParameter(id = "inp", `type` = Option(Coproduct[MyriadInputType](CwlType.File))),
@@ -102,9 +102,8 @@ steps:
     assertCorrectJson(workflow.asCwl, expectedWorkflowJsonString)
   }
 
-  it should "encode sample CWL env" in {
+  it should "encode sample CWL env" ignore {
     val tool = CommandLineTool(
-      `class` = "CommandLineTool".narrow,
       baseCommand = Option(Coproduct[BaseCommand]("env")),
       requirements = Option(Array(Coproduct[Requirement](EnvVarRequirement(
         envDef = Array(EnvironmentDef("HELLO", Coproduct[StringOrExpression]("$(inputs.message)")))

--- a/cwl/src/test/scala/wdl4s/cwl/ExportCwlSamplesSpec.scala
+++ b/cwl/src/test/scala/wdl4s/cwl/ExportCwlSamplesSpec.scala
@@ -5,10 +5,16 @@ import shapeless.Coproduct
 import wdl4s.cwl.CommandLineTool.{BaseCommand, StringOrExpression}
 import wdl4s.cwl.WorkflowStepInput.InputSource
 
+
+  /**
+   * BROKEN
+   *
+   * (DB)Ability to write JSON removed due to conflicting circe-yaml cats dependency.
+   * See issue https://github.com/broadinstitute/wdl4s/issues/216 for more information.
+   */
 class ExportCwlSamplesSpec extends FlatSpec with Matchers {
-  //TODO: Re-implement ability to write CWL to Yaml
-  //(DB)Ability to write JSON removed due to conflicting circe-yaml cats dependency
-  def assertCorrectJson(cwl: Cwl, expectedYaml: String) = ??? // ??? shouldBe expectedYaml
+
+  def assertCorrectJson(cwl: Cwl, expectedYaml: String) = ??? // shouldBe expectedYaml
 
   it should "encode sample CWL command line tool" ignore {
     val tool =

--- a/cwl/src/test/scala/wdl4s/cwl/ParsingSpec.scala
+++ b/cwl/src/test/scala/wdl4s/cwl/ParsingSpec.scala
@@ -1,0 +1,35 @@
+package wdl4s.cwl
+
+import org.scalacheck.Properties
+import io.circe.parser._
+import io.circe.refined._
+import io.circe.literal._
+import CwlCodecs._
+
+class WorkflowParsingSpec extends Properties("Workflow Json Parser") {
+
+  def workflowJson(classValue: String) = s"""{"class":"$classValue", "inputs":[], "outputs":[], "steps":[]}"""
+
+  property("accepts the Workflow argument") =
+    decode[Workflow](workflowJson("Workflow")).isRight
+
+  property("doesn't parse w/something other than Workflow as class") =
+    decode[Workflow](workflowJson("wrong")).isLeft
+
+  property("doesn't parse when class argument is missing") =
+    decode[Workflow]("""{"inputs":[], "outputs":[], "steps":[]}""").isLeft
+}
+
+class CommandLineToolParsingSpec extends Properties("CommandLineTool Json Parser") {
+
+  def commandLineToolJson(classValue: String) = s"""{"class":"$classValue", "inputs":[], "outputs":[]}"""
+
+  property("accepts the CommandLineTool argument for class") =
+    decode[CommandLineTool](commandLineToolJson("CommandLineTool")).isRight
+
+  property("doesn't parse w/something other than") =
+    decode[CommandLineTool](commandLineToolJson("wrong")).isLeft
+
+  property("doesn't parse when class argument is missing") =
+    decode[CommandLineTool]("""{"inputs":[], "outputs":[]}""").isLeft
+}

--- a/cwl/src/test/scala/wdl4s/cwl/ThreeStepExample.scala
+++ b/cwl/src/test/scala/wdl4s/cwl/ThreeStepExample.scala
@@ -1,11 +1,9 @@
 package wdl4s.cwl
 
 import shapeless._
-import syntax.singleton._
 import wdl4s.cwl.CommandLineTool.{Argument, BaseCommand, StringOrExpression}
 import wdl4s.cwl.CommandOutputBinding.Glob
 import wdl4s.cwl.WorkflowStep.{Outputs, Run}
-import CwlCodecs._
 
 /*
  This example calls `ps` , then counts the number of processes that match a pattern input.
@@ -26,7 +24,6 @@ object ThreeStepExample extends App {
       outputBinding = Option(psOutputBinding))
 
   val psClt = CommandLineTool(
-    `class` = "CommandLineTool".narrow,
     outputs = Array(psOutputParameter),
     baseCommand = Option(Coproduct[BaseCommand]("ps")),
     stdout = Option(Coproduct[StringOrExpression]("ps-stdOut.txt")))
@@ -52,7 +49,6 @@ object ThreeStepExample extends App {
   val cgrepClt = CommandLineTool(
     inputs = Array(patternInput, fileInput),
     outputs = Array(cgrepOutputParameter),
-    `class` = "CommandLineTool".narrow,
     arguments = cgrepArgs,
     stdout = Option(Coproduct[StringOrExpression]("cgrep-stdOut.txt")),
     requirements = inlineJScriptRequirements)
@@ -80,7 +76,6 @@ object ThreeStepExample extends App {
 
   val wcClt =
     CommandLineTool(
-      `class` = "CommandLineTool".narrow,
       stdout = Option(Coproduct[StringOrExpression]("wc-stdOut.txt")),
       inputs = Array(wcFileCommandInput),
       outputs = Array(wcCltOutput),
@@ -116,12 +111,9 @@ object ThreeStepExample extends App {
   val _inputs = Array(workflowPatternInput)
 
   val threeStepWorkflow =
-    new Workflow(
+    Workflow(
       inputs = _inputs,
       outputs = _outputs,
       steps = Array(psWfStep, grepWfStep, wcWorkflowStep))
 
-  val yaml = cwlToYaml(threeStepWorkflow.asCwl)
-
-  println(yaml)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   val catsV = "1.0.0-MF"
 
   val sprayJsonV = "1.3.2"
-  val circeVersion = "0.8.0"
+  val circeVersion = "0.9.0-M1"
   val lenthallV = "0.28-7e90b62-SNAP"
 
   // Internal collections of dependencies
@@ -28,6 +28,8 @@ object Dependencies {
   val wdlDependencies = List() ++ womDependencies
 
   private val circeDependencies = List(
+    "core",
+    "parser",
     "generic",
     "generic-extras",
     "shapes",
@@ -36,7 +38,6 @@ object Dependencies {
   ).map(m => "io.circe" %% s"circe-$m" % circeVersion)
 
   val cwlDependencies = List(
-    "io.circe" %% "circe-yaml" % "0.6.1",
     "eu.timepit" %% "refined" % "0.8.3",
     "com.lihaoyi" %% "ammonite-ops" % "1.0.1",
     "org.typelevel" %% "cats-effect" % "0.4",


### PR DESCRIPTION
 * nicely omitted when writing Cwl
 *  asserted during JSON Parsing

Some eggs were broken when updating Circe to use Cats 1.0.0-MF:

circe-yaml is lagging, pointing to cats 0.9.0.  Thus ability to write YAML has been removed.  The tests have been retained but ignored in case we restore this functionality.  I know cromwell doesn't depend on this functionality and I don't know @curoli 's needs but this is necessary until 
 * that dependency situation is fixed on circe-yaml.
 * we use another yaml library