### PR TITLE
Make CWL Womification more robust

### DIFF
--- a/cwl/src/main/scala/wdl4s/cwl/CwlFile.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/CwlFile.scala
@@ -1,7 +1,5 @@
 package wdl4s.cwl
 
-import cats.data.Validated._
-import lenthall.validation.ErrorOr._
 import shapeless.syntax.singleton._
 import shapeless.{:+:, CNil, Poly1, Witness, _}
 import wdl4s.cwl.CommandLineTool.{BaseCommand, StringOrExpression}
@@ -56,8 +54,8 @@ case class CommandLineTool private(
                                    temporaryFailCodes: Option[Array[Int]],
                                    permanentFailCodes: Option[Array[Int]]) {
 
-  def womExecutable: ErrorOr[Executable] =
-    Valid(Executable(taskDefinition))
+  def womExecutable: Checked[Executable] =
+    Right(Executable(taskDefinition))
 
 
   object BaseCommandToString extends Poly1 {

--- a/cwl/src/main/scala/wdl4s/cwl/CwlFile.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/CwlFile.scala
@@ -10,6 +10,7 @@ import wdl4s.wom.callable.{Callable, TaskDefinition}
 import wdl4s.wom.executable.Executable
 import wdl4s.wom.expression.WomExpression
 import wdl4s.wom.{CommandPart, RuntimeAttributes}
+import lenthall.Checked
 
 /**
   *
@@ -104,7 +105,7 @@ case class CommandLineTool private(
     //TODO: This output does _not_ capture expressions from the output.outputBinding
     //The implementation must include the expression evaluation pieces as detailed in:
     //http://www.commonwl.org/v1.0/CommandLineTool.html#CommandOutputBinding
-    
+
     // For inputs and outputs, we only keep the variable name in the definition
     val outputs: Set[Callable.OutputDefinition] = this.outputs.map {
       output =>

--- a/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
@@ -9,6 +9,7 @@ import shapeless.syntax.singleton._
 import CwlVersion._
 import cats.data.NonEmptyList
 import lenthall.validation.ErrorOr._
+import lenthall.Checked
 import shapeless._
 import wdl4s.cwl.CwlType.CwlType
 import wdl4s.cwl.CwlVersion._

--- a/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/Workflow.scala
@@ -1,14 +1,13 @@
 package wdl4s.cwl
 
-import cats.data.Validated._
 import cats.instances.list._
-import cats.syntax.option._
+import cats.syntax.either._
 import cats.syntax.traverse._
 import CwlType._
 import shapeless._
 import shapeless.syntax.singleton._
 import CwlVersion._
-import cats.data.Validated._
+import cats.data.NonEmptyList
 import lenthall.validation.ErrorOr._
 import shapeless._
 import wdl4s.cwl.CwlType.CwlType
@@ -27,7 +26,7 @@ case class Workflow private(
                      outputs: Array[WorkflowOutputParameter],
                      steps: Array[WorkflowStep]) {
 
-  def womExecutable: ErrorOr[Executable] = womDefinition map Executable.apply
+  def womExecutable: Checked[Executable] = womDefinition map Executable.apply
 
   val fileNames: List[String] = steps.toList.flatMap(_.run.select[String].toList)
 
@@ -40,7 +39,7 @@ case class Workflow private(
 
   lazy val stepById: Map[String, WorkflowStep] = steps.map(ws => ws.id -> ws).toMap
 
-  def womGraph: ErrorOr[Graph] = {
+  def womGraph: Checked[Graph] = {
 
     def cwlTypeForInputParameter(input: InputParameter): Option[CwlType] = input.`type`.flatMap(_.select[CwlType])
 
@@ -67,33 +66,39 @@ case class Workflow private(
           workflowInput.name -> workflowInput.singleOutputPort
       }.toMap
 
-    val graphFromSteps: Set[GraphNode] =
+    val graphFromSteps: Checked[Set[GraphNode]] =
       steps.
         toList.
-        foldLeft(Set.empty[GraphNode] ++ graphFromInputs)(
-          (nodes, step) => step.callWithInputs(typeMap,  this, nodes, workflowInputs))
+        foldLeft((Set.empty[GraphNode] ++ graphFromInputs).asRight[NonEmptyList[String]])(
+          (nodes, step) => nodes.flatMap(step.callWithInputs(typeMap,  this, _, workflowInputs)))
 
-    val graphFromOutputs: ErrorOr[Set[GraphNode]] =
+    val graphFromOutputs: Checked[Set[GraphNode]] =
       outputs.toList.traverse[ErrorOr, GraphNode] {
         output =>
 
           val wdlType = cwlTypeToWdlType(output.`type`.flatMap(_.select[CwlType]).get)
 
-          def lookupOutputSource(outputId: WorkflowOutputId): ErrorOr[OutputPort] = {
-            (for {
-              call <- graphFromSteps.collectFirst { case callNode: CallNode if callNode.name == outputId.stepId => callNode }
-              output <- call.outputPorts.find(_.name == outputId.outputId)
-            } yield output).toValidNel(s"unable to find upstream port corresponding to ${outputId.stepId}/${outputId.outputId}")
-          }
+          def lookupOutputSource(outputId: WorkflowOutputId): Checked[OutputPort] =
+            for {
+              set <- graphFromSteps
+              call <- set.collectFirst { case callNode: CallNode if callNode.name == outputId.stepId => callNode }.
+                toRight(NonEmptyList.one(s"Call Node by name ${outputId.stepId} was not found in set $set"))
+              output <- call.outputPorts.find(_.name == outputId.outputId).
+                          toRight(NonEmptyList.one(s"looking for ${outputId.outputId} in call $call output ports ${call.outputPorts}"))
+            } yield output
 
           lookupOutputSource(WorkflowOutputId(output.outputSource.flatMap(_.select[String]).get)).
-            map(PortBasedGraphOutputNode(output.id, wdlType, _))
-      }.map(_.toSet)
+            map(PortBasedGraphOutputNode(output.id, wdlType, _)).toValidated
+      }.map(_.toSet).toEither
 
-    graphFromOutputs.flatMap(outputs => Graph.validateAndConstruct(graphFromSteps ++ graphFromInputs ++ outputs))
+    for {
+      outputs <- graphFromOutputs
+      steps <- graphFromSteps
+      ret <- Graph.validateAndConstruct(steps ++ graphFromInputs ++ outputs).toEither
+    } yield ret
   }
 
-  def womDefinition: ErrorOr[WorkflowDefinition] = {
+  def womDefinition: Checked[WorkflowDefinition] = {
     // TODO: need to find a way to get a meaningful name here
     val name: String = "MyCwlWorkflow"
     val meta: Map[String, String] = Map.empty

--- a/cwl/src/main/scala/wdl4s/cwl/WorkflowStep.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/WorkflowStep.scala
@@ -7,6 +7,7 @@ import wdl4s.cwl.ScatterMethod._
 import wdl4s.cwl.WorkflowStep.{Outputs, Run}
 import wdl4s.wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 import wdl4s.wom.graph.{CallNode, GraphNode, TaskCallNode}
+import lenthall.Checked
 
 import scala.language.postfixOps
 import scala.util.Try

--- a/cwl/src/main/scala/wdl4s/cwl/WorkflowStep.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/WorkflowStep.scala
@@ -1,5 +1,7 @@
 package wdl4s.cwl
 
+import cats.data.NonEmptyList
+import cats.syntax.either._
 import shapeless._
 import wdl4s.cwl.ScatterMethod._
 import wdl4s.cwl.WorkflowStep.{Outputs, Run}
@@ -13,7 +15,7 @@ import scala.util.Try
   * An individual job to run.
   *
   * @see <a href="http://www.commonwl.org/v1.0/Workflow.html#WorkflowStep">CWL Spec | Workflow Step</a>
-  * @param run Purposefully not defaulted as it's required and it is unreasonable to not have something to run.
+  * @param run Purposefully not defaulted as it's required in the specification and it is unreasonable to not have something to run.
   */
 case class WorkflowStep(
                          id: String,
@@ -26,6 +28,7 @@ case class WorkflowStep(
                          doc: Option[String] = None,
                          scatter: Option[String :+: Array[String] :+: CNil] = None,
                          scatterMethod: Option[ScatterMethod] = None) {
+
 
   def typedOutputs: WdlTypeMap = run.fold(RunOutputsToTypeMap)
 
@@ -41,12 +44,12 @@ case class WorkflowStep(
   def callWithInputs(typeMap: WdlTypeMap,
                      workflow: Workflow,
                      knownNodes: Set[GraphNode],
-                     workflowInputs: Map[String, GraphNodeOutputPort]): Set[GraphNode] = {
+                     workflowInputs: Map[String, GraphNodeOutputPort]): Checked[Set[GraphNode]] = {
 
     // To avoid duplicating nodes, return immediately if we've already covered this node
     val haveWeSeenThisStep: Boolean = knownNodes.collect { case TaskCallNode(name, _, _, _) => name }.contains(unqualifiedStepId)
 
-    if (haveWeSeenThisStep) knownNodes
+    if (haveWeSeenThisStep) Right(knownNodes)
     else {
       // Create a task definition for the underlying run.
       // For sub workflows, we'll need to handle the case where this could be a workflow definition
@@ -60,9 +63,10 @@ case class WorkflowStep(
         *   1) link each input of the step to an output port (which at this point can be from a different step or from a workflow input)
         *   2) accumulate the nodes created along the way to achieve 1)
         */
-      def foldInputs(mapAndNodes: (Map[String, OutputPort], Set[GraphNode]),
-                     workflowStepInput: WorkflowStepInput): (Map[String, OutputPort], Set[GraphNode]) = mapAndNodes match {
-        case ((map, knownNodes)) => //shadowing knownNodes on purpose to avoid accidentally referencing the outer one
+      def foldInputs(mapAndNodes: Checked[(Map[String, OutputPort],  Set[GraphNode])],
+                     workflowStepInput: WorkflowStepInput): Checked[(Map[String, OutputPort], Set[GraphNode])] =
+        mapAndNodes flatMap {
+        case (map, knownNodes) => //shadowing knownNodes on purpose to avoid accidentally referencing the outer one
 
           // The source from which we expect to satisfy this input (output from other step or workflow input)
           // TODO: this can be None in which case we should look if the "default" field is defined
@@ -73,11 +77,13 @@ case class WorkflowStep(
             * This is useful when we've determined that the input points to an output of a different step and we want
             * to get the corresponding output port.
            */
-          def findThisInputInSet(set: Set[GraphNode], stepId: String, stepOutputId: String): Option[OutputPort] = {
+          def findThisInputInSet(set: Set[GraphNode], stepId: String, stepOutputId: String): Checked[OutputPort] = {
             for {
             // We only care for outputPorts of call nodes
-              call <- set.collectFirst { case callNode: CallNode if callNode.name == stepId => callNode }
-              output <- call.outputPorts.find(_.name == stepOutputId)
+              call <- set.collectFirst { case callNode: CallNode if callNode.name == stepId => callNode }.
+                        toRight(NonEmptyList.one(s"stepId $stepId not found in known Nodes $set"))
+              output <- call.outputPorts.find(_.name == stepOutputId).
+                          toRight(NonEmptyList.one(s"step output id $stepOutputId not found in ${call.outputPorts}"))
             } yield output
           }
 
@@ -85,13 +91,13 @@ case class WorkflowStep(
             * Build a wom node for the given step and return the newly created nodes
             * This is useful when we've determined that the input belongs to an upstream step that we haven't covered yet
            */
-          def buildUpstreamNodes(upstreamStepId: String): Set[GraphNode] = {
-            //TODO: Option get!
+          def buildUpstreamNodes(upstreamStepId: String): Checked[Set[GraphNode]] =
             // Find the step corresponding to this upstreamStepId in the set of all the steps of this workflow
-            val step: WorkflowStep = workflow.steps.find { step => WorkflowStepId(step.id).stepId == upstreamStepId }.get
-
-            step.callWithInputs(typeMap, workflow, knownNodes, workflowInputs)
-          }
+            for {
+              step <- workflow.steps.find { step => WorkflowStepId(step.id).stepId == upstreamStepId }.
+                        toRight(NonEmptyList.one(s"no step of id $upstreamStepId found in ${workflow.steps.map(_.id)}"))
+              call <- step.callWithInputs(typeMap, workflow, knownNodes, workflowInputs)
+            } yield call
 
           // Parse the workflowStepInput to be able to access its components separately
           val parsedStepInputId = WorkflowStepInputOrOutputId(workflowStepInput.id)
@@ -103,7 +109,7 @@ case class WorkflowStep(
             * e.g:
             * workflow step input could be: file:///Users/danb/wdl4s/r.cwl#cgrep/pattern
             * with a task description input: file:///Users/danb/wdl4s/r.cwl#cgrep/09f8bcac-a91a-49d5-afb6-2f1b1294e875/pattern
-            * 
+            *
             * The file name part could even be different if they have been saladed at a different time / place
            */
           val taskDefinitionInput = taskDefinition.inputs.map(_.name).find(_ == parsedStepInputId.ioId).getOrElse {
@@ -112,7 +118,7 @@ case class WorkflowStep(
 
           /*
             * Parse the inputSource (what this input is pointing to)
-            * 2 cases: 
+            * 2 cases:
             *   - points to a workflow input
             *   - points to an upstream step
            */
@@ -120,47 +126,50 @@ case class WorkflowStep(
             // The source points to a workflow input, which means it should be in the workflowInputs map
             case _: WorkflowInputId =>
 
-              // Try to find it in the workflow inputs map, if we can't it's an error 
+              // Try to find it in the workflow inputs map, if we can't it's an error
               // TODO: (at least for now, it's possible to provide a default value but we don't support it yet)
-              val outputPortMapping: (String, OutputPort) = workflowInputs collectFirst {
+              val outputPortMapping: Checked[(String, OutputPort)] = workflowInputs.collectFirst {
                 case (inputId, port) if inputSource == inputId => taskDefinitionInput -> port
-              } getOrElse (throw new Exception(s"Can't find workflow input for $inputSource"))
+              }.toRight(NonEmptyList.one(s"Can't find workflow input for $inputSource"))
 
-              (map + outputPortMapping, knownNodes)
+              outputPortMapping.map(mapping => (map + mapping) -> knownNodes)
 
             // The source points to an output from a different step
             case WorkflowStepInputOrOutputId(_, stepId, stepOutputId) =>
-              val newNodesAndOutputPort: Option[(Set[GraphNode], OutputPort)] =
-                // First check if we've already built the WOM node for this step, and if so return the associated output port
+              val newNodesAndOutputPort: Checked[(Set[GraphNode], OutputPort)] =
+              // First check if we've already built the WOM node for this step, and if so return the associated output port
                 findThisInputInSet(knownNodes, stepId, stepOutputId).map(Set.empty[GraphNode] -> _)
-                .orElse {
-                  // Otherwise build the upstream nodes
-                  val newNodes = buildUpstreamNodes(stepId)
-                  // And look again in those newly created nodes
-                  findThisInputInSet(newNodes, stepId, stepOutputId) map { newNodes -> _ }
-                }
-
-              //TODO: Option . get makes kittens sad
-              val (newNodes, outputPort) = newNodesAndOutputPort.get
+                  .orElse {
+                    // Otherwise build the upstream nodes
+                    val newNodes = buildUpstreamNodes(stepId)
+                    // And look again in those newly created nodes
+                    newNodes.flatMap(nodes => findThisInputInSet(nodes, stepId, stepOutputId) map {
+                      nodes -> _
+                    })
+                  }
 
               // Note that the key is the taskDefinitionInput (which in our previous example would be "pattern")
               // This is because WOM is going to use this map to link input ports to output ports
               // and will use the taskDefinition input port names to do so.
               // So we need to make sure that the keys in this map match the task definition input names (and not the workflow step input names !)
-              (map + (taskDefinitionInput -> outputPort), knownNodes ++ newNodes)
-            case _ => (map, knownNodes) //TODO: This should "fail fast" as Invalid here as it won't pass validation
+              newNodesAndOutputPort.map {
+                case (newNodes, outputPort) => (map + (taskDefinitionInput -> outputPort), knownNodes ++ newNodes)
+              }
           }
       }
-      
-      // We fold over inputs for this step and build an input -> output port lookup map as well as nodes created along the way
-      val workflowOutputsMap: (Map[String, OutputPort], Set[GraphNode]) =
-        in.foldLeft((Map.empty[String, OutputPort], knownNodes)) (foldInputs)
 
-      // TODO: getOrElse(???) nooooooooo
+      // We fold over inputs for this step and build an input -> output port lookup map as well as nodes created along the way
+      val workflowOutputsMap: Checked[(Map[String, OutputPort], Set[GraphNode])] =
+        in.foldLeft((Map.empty[String, OutputPort] -> knownNodes).asRight[NonEmptyList[String]]) (foldInputs)
+
       // Use what we've got to generate a call node and required input nodes
       // However here we expect WOM NOT to return any required input nodes because it would mean that some task definition inputs
       // have not been linked to either a workflow input or an upstream output, in which case they have no other way to be satisfied ( <- is that true ?)
-      CallNode.callWithInputs(unqualifiedStepId, taskDefinition, workflowInputs ++ workflowOutputsMap._1, Set.empty, prefixSeparator = "#").getOrElse(???).nodes ++ workflowOutputsMap._2
+      for {
+        mapsAndNodes <- workflowOutputsMap
+        (map, nodes) = mapsAndNodes
+        call <-  CallNode.callWithInputs(unqualifiedStepId, taskDefinition, workflowInputs ++ map, Set.empty, prefixSeparator = "#").toEither
+      } yield  call.nodes ++ nodes
     }
   }
 }

--- a/cwl/src/main/scala/wdl4s/cwl/package.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/package.scala
@@ -1,9 +1,9 @@
 package wdl4s
 
+import cats.data.NonEmptyList
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string._
 import eu.timepit.refined._
-import lenthall.validation.ErrorOr.ErrorOr
 import wdl4s.cwl.CwlType.CwlType
 import wdl4s.cwl.CwlType._
 import wdl4s.wdl.types._
@@ -12,25 +12,6 @@ import wdl4s.wom.executable.Executable
 
 /**
  * This package is intended to parse all CWL files.
- *
- * =Usage=
- * {{{
- * import wdl4s.cwl._
- *
- * val firstTool = """
- * cwlVersion: v1.0
- * class: CommandLineTool
- * baseCommand: echo
- * inputs:
- *   message:
- *     type: string
- *     inputBinding:
- *       position: 1
- * outputs: []
- * """
- * decodeCwl(firstTool) //returns Either[Error, Cwl]
- * }}}
- *
  *
  * It makes heavy use of Circe YAML/Json auto derivation feature and
  * Circe modules that support the Scala libraries shapeless and Refined.
@@ -52,6 +33,8 @@ package object cwl extends TypeAliases {
 
   type Cwl = Workflow :+: CommandLineTool :+: CNil
 
+  type Checked[A] = Either[NonEmptyList[String], A]
+
   def cwlTypeToWdlType : CwlType => WdlType = {
     case Null => WdlNothingType
     case Boolean => WdlBooleanType
@@ -63,7 +46,6 @@ package object cwl extends TypeAliases {
     case CwlType.File => WdlFileType
     case CwlType.Directory => ???
   }
-
 
   /**
     *
@@ -80,6 +62,6 @@ package object cwl extends TypeAliases {
   }
 
   implicit class CwlHelper(val cwl: Cwl) extends AnyVal {
-    def womExecutable: ErrorOr[Executable] = cwl.fold(CwlToWomExecutable)
+    def womExecutable: Checked[Executable] = cwl.fold(CwlToWomExecutable)
   }
 }

--- a/cwl/src/main/scala/wdl4s/cwl/package.scala
+++ b/cwl/src/main/scala/wdl4s/cwl/package.scala
@@ -1,6 +1,5 @@
 package wdl4s
 
-import cats.data.NonEmptyList
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string._
 import eu.timepit.refined._
@@ -9,6 +8,7 @@ import wdl4s.cwl.CwlType._
 import wdl4s.wdl.types._
 import shapeless._
 import wdl4s.wom.executable.Executable
+import lenthall.Checked
 
 /**
  * This package is intended to parse all CWL files.
@@ -32,8 +32,6 @@ import wdl4s.wom.executable.Executable
 package object cwl extends TypeAliases {
 
   type Cwl = Workflow :+: CommandLineTool :+: CNil
-
-  type Checked[A] = Either[NonEmptyList[String], A]
 
   def cwlTypeToWdlType : CwlType => WdlType = {
     case Null => WdlNothingType

--- a/cwl/src/test/scala/wdl4s/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/wdl4s/cwl/CwlWorkflowWomSpec.scala
@@ -48,7 +48,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers {
               map(_.select[CommandLineTool].get).
               value.
               unsafeRunSync
-      wom <-  clt.womExecutable
+      wom <- clt.womExecutable
     } yield validateWom(wom)).leftMap(e => throw new RuntimeException(s"error! $e"))
   }
 
@@ -103,7 +103,8 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers {
 
     val wfd = wf.womExecutable match {
       case Right(Executable(wf: WorkflowDefinition)) => wf
-      case o => fail(s"invalid executable $o")
+      case Left(o) => fail(s"Workflow definition was not produced correctly: ${o.toList.mkString(", ")}")
+      case Right(Executable(callable)) => fail(s"produced $callable when a Workflow Definition was expected!")
     }
 
     val nodes = wfd.innerGraph.nodes

--- a/cwl/src/test/scala/wdl4s/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/wdl4s/cwl/CwlWorkflowWomSpec.scala
@@ -1,6 +1,5 @@
 package wdl4s.cwl
 
-import cats.data.Validated.Valid
 import cats.syntax.either._
 import org.scalatest.{FlatSpec, Matchers}
 import wdl4s.cwl.CwlDecoder._
@@ -49,7 +48,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers {
               map(_.select[CommandLineTool].get).
               value.
               unsafeRunSync
-      wom <-  clt.womExecutable.toEither
+      wom <-  clt.womExecutable
     } yield validateWom(wom)).leftMap(e => throw new RuntimeException(s"error! $e"))
   }
 
@@ -60,7 +59,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers {
               unsafeRunSync.
               map(_.select[Workflow].get)
 
-      ex <- wf.womExecutable.toEither
+      ex <- wf.womExecutable
     } yield validateWom(ex)).leftMap(e => throw new RuntimeException(s"error! $e"))
 
     def validateWom(ex: Executable) = {
@@ -103,7 +102,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers {
     }.value.unsafeRunSync.fold(error => throw new RuntimeException(s"broken parse! msg was $error"), identity)
 
     val wfd = wf.womExecutable match {
-      case Valid(Executable(wf: WorkflowDefinition)) => wf
+      case Right(Executable(wf: WorkflowDefinition)) => wf
       case o => fail(s"invalid executable $o")
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   val sprayJsonV = "1.3.2"
   val circeVersion = "0.9.0-M1"
-  val lenthallV = "0.28-7e90b62-SNAP"
+  val lenthallV = "0.28-f5f7f86-SNAP"
 
   // Internal collections of dependencies
 


### PR DESCRIPTION
There is quite a bit of technical debt in CWL -> WOM.

This PR addresses the getOrElse that took a pure value from an `ErrorOr`.

As we were `flatMap`-ing quite regularly, I took the initiative to introduce the type parameter:
`type Checked[A] = Either[NonEmptyList[String], A]` which is analogous to `ErrorOr`.