### PR TITLE
Fix outputEval expression.

### DIFF
--- a/cwl/src/test/resources/three_step.cwl
+++ b/cwl/src/test/resources/three_step.cwl
@@ -45,7 +45,7 @@ steps:
       outputBinding:
         glob: cgrep-stdOut.txt
         loadContents: true
-        outputEval: $(self[0].contents.toInt)
+        outputEval: $(parseInt(self[0].contents))
       type: int
     class: CommandLineTool
     requirements:
@@ -81,7 +81,7 @@ steps:
       outputBinding:
         glob: wc-stdOut.txt
         loadContents: true
-        outputEval: $(self[0].contents.toInt)
+        outputEval: $(parseInt(self[0].contents))
       type: int
     class: CommandLineTool
     requirements:


### PR DESCRIPTION
Minor fix to make this actually able to run in `cwltool`. Pretty sure I saw this run at one point, not sure why it's not right on develop now. :man_shrugging: 