### PR TITLE
scalafmt plugin added

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+style = Intellij
+maxColumn = 100
+rewrite.rules = [SortImports, RedundantBraces]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.12")


### PR DESCRIPTION
enables running `scalafmt` on demand to reformat source according to rules in `.scalafmt.conf`.