### PR TITLE
Switching GraphNode equality to object identity-based

### DIFF
--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import shapeless._
 import cwl.CwlDecoder._
-import wdl.types.{WdlFileType, WdlStringType}
+import wdl.types.{WdlFileType, WdlStringType, WdlType}
 import wom.WomMatchers._
 import wom.callable.Callable.RequiredInputDefinition
 import wom.callable.{Callable, TaskDefinition, WorkflowDefinition}
@@ -59,6 +59,14 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
       womDefinition <- wf.womDefinition
     } yield validateWom(womDefinition)).leftMap(e => throw new RuntimeException(s"error! $e"))
 
+    def shouldBeRequiredGraphInputNode(node: GraphNode, name: String, wdlType: WdlType): Unit = {
+      node.isInstanceOf[RequiredGraphInputNode] shouldBe true
+      val requiredGraphInputNode = node.asInstanceOf[RequiredGraphInputNode]
+      requiredGraphInputNode.name shouldBe name
+      requiredGraphInputNode.womType shouldBe wdlType
+      ()
+    }
+
     def validateWom(callable: Callable) = {
       callable match {
         case wf: WorkflowDefinition =>
@@ -80,17 +88,12 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
           untarUpstream should have size 2
           untarUpstream.collectFirst({
             case exprNode: ExpressionNode if exprNode.name == s"file://$rootPath/1st-workflow.cwl#untar/extractfile" =>
-              val graphNode = exprNode.inputPorts.head.upstream.graphNode
-              graphNode.isInstanceOf[RequiredGraphInputNode] shouldBe true
-              val requiredGraphInputNode = graphNode.asInstanceOf[RequiredGraphInputNode]
-              requiredGraphInputNode.name shouldBe "ex"
-              requiredGraphInputNode.womType shouldBe WdlStringType
-              exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode("ex", WdlStringType)
+              shouldBeRequiredGraphInputNode(exprNode.inputPorts.head.upstream.graphNode, "ex", WdlStringType)
           }).getOrElse(fail("Can't find expression node for ex"))
           
           untarUpstream.collectFirst({
             case exprNode: ExpressionNode if exprNode.name == s"file://$rootPath/1st-workflow.cwl#untar/tarfile" =>
-              exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode("inp", WdlFileType)
+              shouldBeRequiredGraphInputNode(exprNode.inputPorts.head.upstream.graphNode, "inp", WdlFileType)
           }).getOrElse(fail("Can't find expression node for inp"))
 
           val compileUpstreamExpressionPort = nodes.collectFirst {

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -80,6 +80,11 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
           untarUpstream should have size 2
           untarUpstream.collectFirst({
             case exprNode: ExpressionNode if exprNode.name == s"file://$rootPath/1st-workflow.cwl#untar/extractfile" =>
+              val graphNode = exprNode.inputPorts.head.upstream.graphNode
+              graphNode.isInstanceOf[RequiredGraphInputNode] shouldBe true
+              val requiredGraphInputNode = graphNode.asInstanceOf[RequiredGraphInputNode]
+              requiredGraphInputNode.name shouldBe "ex"
+              requiredGraphInputNode.womType shouldBe WdlStringType
               exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode("ex", WdlStringType)
           }).getOrElse(fail("Can't find expression node for ex"))
           

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -62,7 +62,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
     def shouldBeRequiredGraphInputNode(node: GraphNode, name: String, wdlType: WdlType): Unit = {
       node.isInstanceOf[RequiredGraphInputNode] shouldBe true
       val requiredGraphInputNode = node.asInstanceOf[RequiredGraphInputNode]
-      requiredGraphInputNode.name shouldBe name
+      requiredGraphInputNode.localName shouldBe name
       requiredGraphInputNode.womType shouldBe wdlType
       ()
     }

--- a/wom/src/main/scala/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphNode.scala
@@ -11,6 +11,10 @@ trait GraphNode {
 
   def name: String
 
+  final override def equals(other: Any): Boolean = super.equals(other)
+
+  final override def hashCode: Int = super.hashCode()
+
   /**
     * Inputs that must be available before this graph node can be run.
     */


### PR DESCRIPTION
Switched GraphNode.equals and GraphNode.hashCode to object identity-based equality instead of component-based.

Updated two unit tests that relied on conponent-based equality.