### PR TITLE
[Pregull] WomIdentifier

### DIFF
--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -13,7 +13,7 @@ case class CwlExpressionCommandPart(expr: Expression) extends CommandPart {
                            functions: IoFunctionSet,
                            valueMapper: (WdlValue) => WdlValue): String = {
 
-    val pc = ParameterContext.Empty.withInputs(inputsMap.map({ case (key, value) => key.asString -> value }), functions)
+    val pc = ParameterContext.Empty.withInputs(inputsMap.map({ case (LocalName(localName), value) => localName -> value }), functions)
 
     val wdlValue: WdlValue = expr.fold(EvaluateExpression).apply(pc)
 

--- a/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
+++ b/cwl/src/main/scala/cwl/CwlExpressionCommandPart.scala
@@ -5,14 +5,15 @@ import wom.CommandPart
 import wom.expression.IoFunctionSet
 import CwlWomExpression._
 import wdl4s.cwl.EvaluateExpression
+import wom.graph.LocalName
 
 
 case class CwlExpressionCommandPart(expr: Expression) extends CommandPart {
-  override def instantiate(inputsMap: Map[String, WdlValue],
-                            functions: IoFunctionSet,
-                            valueMapper: (WdlValue) => WdlValue): String = {
+  override def instantiate(inputsMap: Map[LocalName, WdlValue],
+                           functions: IoFunctionSet,
+                           valueMapper: (WdlValue) => WdlValue): String = {
 
-    val pc = ParameterContext.Empty.withInputs(inputsMap, functions)
+    val pc = ParameterContext.Empty.withInputs(inputsMap.map({ case (key, value) => key.asString -> value }), functions)
 
     val wdlValue: WdlValue = expr.fold(EvaluateExpression).apply(pc)
 

--- a/cwl/src/main/scala/cwl/CwlWomExpression.scala
+++ b/cwl/src/main/scala/cwl/CwlWomExpression.scala
@@ -18,6 +18,8 @@ sealed trait CwlWomExpression extends WomExpression {
 case class CommandOutputExpression(outputBinding: CommandOutputBinding,
                                    override val cwlExpressionType: WdlType) extends CwlWomExpression {
 
+  // TODO WOM: outputBinding.toString is probably not be the best representation of the outputBinding
+  override def sourceString = outputBinding.toString
   override def evaluateValue(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue] = {
     val parameterContext = ParameterContext.Empty.withInputs(inputValues, ioFunctionSet)
 

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -61,11 +61,11 @@ case class Workflow private(
         val parsedInputId = WorkflowInputId(inputParameter.id).inputId
         val womType = wdlTypeForInputParameter(inputParameter).get
 
-        OptionalGraphInputNodeWithDefault(parsedInputId, womType, PlaceholderWomExpression(Set.empty, womType))
+        OptionalGraphInputNodeWithDefault(WomIdentifier(parsedInputId), womType, PlaceholderWomExpression(Set.empty, womType))
       case input =>
         val parsedInputId = WorkflowInputId(input.id).inputId
 
-        RequiredGraphInputNode(parsedInputId, wdlTypeForInputParameter(input).get)
+        RequiredGraphInputNode(WomIdentifier(parsedInputId), wdlTypeForInputParameter(input).get)
     }.toSet
 
     val workflowInputs: Map[String, GraphNodeOutputPort] =
@@ -96,7 +96,7 @@ case class Workflow private(
             } yield output
 
           lookupOutputSource(WorkflowOutputId(output.outputSource.flatMap(_.select[String]).get)).
-            map(PortBasedGraphOutputNode(output.id, wdlType, _)).toValidated
+            map(PortBasedGraphOutputNode(WomIdentifier(output.id), wdlType, _)).toValidated
       }.map(_.toSet).toEither
 
     for {

--- a/cwl/src/main/scala/cwl/Workflow.scala
+++ b/cwl/src/main/scala/cwl/Workflow.scala
@@ -71,7 +71,7 @@ case class Workflow private(
     val workflowInputs: Map[String, GraphNodeOutputPort] =
       graphFromInputs.map {
         workflowInput =>
-          workflowInput.name -> workflowInput.singleOutputPort
+          workflowInput.localName -> workflowInput.singleOutputPort
       }.toMap
 
     val graphFromSteps: Checked[Set[GraphNode]] =
@@ -89,7 +89,7 @@ case class Workflow private(
           def lookupOutputSource(outputId: WorkflowOutputId): Checked[OutputPort] =
             for {
               set <- graphFromSteps
-              call <- set.collectFirst { case callNode: CallNode if callNode.name == outputId.stepId => callNode }.
+              call <- set.collectFirst { case callNode: CallNode if callNode.localName == outputId.stepId => callNode }.
                 toRight(NonEmptyList.one(s"Call Node by name ${outputId.stepId} was not found in set $set"))
               output <- call.outputPorts.find(_.name == outputId.outputId).
                           toRight(NonEmptyList.one(s"looking for ${outputId.outputId} in call $call output ports ${call.outputPorts}"))

--- a/cwl/src/main/scala/cwl/WorkflowStep.scala
+++ b/cwl/src/main/scala/cwl/WorkflowStep.scala
@@ -48,7 +48,7 @@ case class WorkflowStep(
 
   def fileName: Option[String] = run.select[String]
 
-  val unqualifiedStepId = Try(WorkflowStepId(id)).map(_.stepId).getOrElse(id)
+  val unqualifiedStepId = WomIdentifier(Try(WorkflowStepId(id)).map(_.stepId).getOrElse(id))
 
   /**
     * Generates all GraphNodes necessary to represent call nodes and input nodes
@@ -61,7 +61,7 @@ case class WorkflowStep(
                      workflowInputs: Map[String, GraphNodeOutputPort]): Checked[Set[GraphNode]] = {
 
     // To avoid duplicating nodes, return immediately if we've already covered this node
-    val haveWeSeenThisStep: Boolean = knownNodes.collect { case TaskCallNode(name, _, _, _) => name.localName.asString }.contains(unqualifiedStepId)
+    val haveWeSeenThisStep: Boolean = knownNodes.collect { case TaskCallNode(identifier, _, _, _) => identifier }.contains(unqualifiedStepId)
 
     if (haveWeSeenThisStep) Right(knownNodes)
     else {
@@ -98,7 +98,7 @@ case class WorkflowStep(
           def findThisInputInSet(set: Set[GraphNode], stepId: String, stepOutputId: String): Checked[OutputPort] = {
             for {
             // We only care for outputPorts of call nodes
-              call <- set.collectFirst { case callNode: CallNode if callNode.name == stepId => callNode }.
+              call <- set.collectFirst { case callNode: CallNode if callNode.localName == stepId => callNode }.
                 toRight(NonEmptyList.one(s"stepId $stepId not found in known Nodes $set"))
               output <- call.outputPorts.find(_.name == stepOutputId).
                 toRight(NonEmptyList.one(s"step output id $stepOutputId not found in ${call.outputPorts}"))
@@ -210,7 +210,7 @@ case class WorkflowStep(
       for {
         stepInputFold <- in.foldLeft(WorkflowStepInputFold.emptyRight)(foldStepInput)
         inputDefinitionFold <- taskDefinition.inputs.foldMap(foldInputDefinition(stepInputFold.stepInputMapping)).toEither
-        callAndNodes = callNodeBuilder.build(WomIdentifier(unqualifiedStepId), taskDefinition, inputDefinitionFold)
+        callAndNodes = callNodeBuilder.build(unqualifiedStepId, taskDefinition, inputDefinitionFold)
       } yield stepInputFold.generatedNodes ++ callAndNodes.nodes ++ knownNodes
     }
   }

--- a/cwl/src/test/scala/cwl/CwlExpressionCommandPartSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlExpressionCommandPartSpec.scala
@@ -7,6 +7,7 @@ import ExpressionEvaluator._
 import shapeless.Coproduct
 import wdl.values.WdlString
 import wom.expression.PlaceholderIoFunctionSet
+import wom.graph.LocalName
 
 class CwlExpressionCommandPartSpec extends FlatSpec with Matchers {
 
@@ -17,7 +18,7 @@ class CwlExpressionCommandPartSpec extends FlatSpec with Matchers {
     // https://stackoverflow.com/questions/25989642/why-does-java-8-nashorn-javascript-modulo-returns-0-0-double-instead-of-0-i#answer-25991982
     // https://community.apigee.com/questions/33936/javascript-parseint-not-converting-to-int-value-ne.html
     val commandPart = CwlExpressionCommandPart(Coproduct[Expression](refineMV[MatchesRegex[ECMAScriptExpressionWitness.T]]("$(parseInt(inputs.myStringInt).toFixed())")))
-    val result = commandPart.instantiate(Map("myStringInt" -> WdlString("3")), PlaceholderIoFunctionSet, identity)
+    val result = commandPart.instantiate(Map(LocalName("myStringInt") -> WdlString("3")), PlaceholderIoFunctionSet, identity)
     result should be("3")
   }
 

--- a/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlInputValidationSpec.scala
@@ -53,14 +53,14 @@ class CwlInputValidationSpec extends FlatSpec with Matchers with TableDrivenProp
     case Right(womDef) => womDef.graph.getOrElse(fail("Failed to build wom graph"))
   }
 
-  lazy val w0OutputPort = graph.inputNodes.find(_.name == "w0").getOrElse(fail("Failed to find an input node for w0")).singleOutputPort
-  lazy val w1OutputPort = graph.inputNodes.find(_.name == "w1").getOrElse(fail("Failed to find an input node for w1")).singleOutputPort
-  lazy val w2OutputPort = graph.inputNodes.find(_.name == "w2").getOrElse(fail("Failed to find an input node for w2")).singleOutputPort
-  lazy val w3OutputPort = graph.inputNodes.find(_.name == "w3").getOrElse(fail("Failed to find an input node for w3")).singleOutputPort
-  lazy val w4OutputPort = graph.inputNodes.find(_.name == "w4").getOrElse(fail("Failed to find an input node for w4")).singleOutputPort
-  lazy val w5OutputPort = graph.inputNodes.find(_.name == "w5").getOrElse(fail("Failed to find an input node for w5")).singleOutputPort
-  lazy val w6OutputPort = graph.inputNodes.find(_.name == "w6").getOrElse(fail("Failed to find an input node for w6")).singleOutputPort
-  lazy val w7OutputPort = graph.inputNodes.find(_.name == "w7").getOrElse(fail("Failed to find an input node for w7")).singleOutputPort
+  lazy val w0OutputPort = graph.inputNodes.find(_.localName == "w0").getOrElse(fail("Failed to find an input node for w0")).singleOutputPort
+  lazy val w1OutputPort = graph.inputNodes.find(_.localName == "w1").getOrElse(fail("Failed to find an input node for w1")).singleOutputPort
+  lazy val w2OutputPort = graph.inputNodes.find(_.localName == "w2").getOrElse(fail("Failed to find an input node for w2")).singleOutputPort
+  lazy val w3OutputPort = graph.inputNodes.find(_.localName == "w3").getOrElse(fail("Failed to find an input node for w3")).singleOutputPort
+  lazy val w4OutputPort = graph.inputNodes.find(_.localName == "w4").getOrElse(fail("Failed to find an input node for w4")).singleOutputPort
+  lazy val w5OutputPort = graph.inputNodes.find(_.localName == "w5").getOrElse(fail("Failed to find an input node for w5")).singleOutputPort
+  lazy val w6OutputPort = graph.inputNodes.find(_.localName == "w6").getOrElse(fail("Failed to find an input node for w6")).singleOutputPort
+  lazy val w7OutputPort = graph.inputNodes.find(_.localName == "w7").getOrElse(fail("Failed to find an input node for w7")).singleOutputPort
   
   def validate(inputFile: String): Map[GraphNodePort.OutputPort, ResolvedExecutableInput] = {
     cwlWorkflow.womExecutable(Option(inputFile)) match {

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -65,31 +65,31 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
           val nodes = wf.innerGraph.nodes
 
           nodes collect {
-            case gin: GraphInputNode => gin.name
+            case gin: GraphInputNode => gin.localName
           } should be(Set("ex", "inp"))
 
           nodes collect {
-            case cn: CallNode => cn.name
+            case cn: CallNode => cn.localName
           } should be(Set("compile", "untar"))
 
           val untarUpstream = nodes.collectFirst {
-            case tarParam: CallNode if tarParam.name == s"untar" => tarParam
+            case tarParam: CallNode if tarParam.localName == s"untar" => tarParam
           }.get.
             upstream
           
           untarUpstream should have size 2
           untarUpstream.collectFirst({
-            case exprNode: ExpressionNode if exprNode.name == s"file://$rootPath/1st-workflow.cwl#untar/extractfile" =>
+            case exprNode: ExpressionNode if exprNode.localName == s"file://$rootPath/1st-workflow.cwl#untar/extractfile" =>
               exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode(WomIdentifier("ex"), WdlStringType)
           }).getOrElse(fail("Can't find expression node for ex"))
           
           untarUpstream.collectFirst({
-            case exprNode: ExpressionNode if exprNode.name == s"file://$rootPath/1st-workflow.cwl#untar/tarfile" =>
+            case exprNode: ExpressionNode if exprNode.localName == s"file://$rootPath/1st-workflow.cwl#untar/tarfile" =>
               exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode(WomIdentifier("inp"), WdlFileType)
           }).getOrElse(fail("Can't find expression node for inp"))
 
           val compileUpstreamExpressionPort = nodes.collectFirst {
-            case compile: CallNode if compile.name == s"compile" => compile
+            case compile: CallNode if compile.localName == s"compile" => compile
           }.get.inputPorts.map(_.upstream).head
 
           compileUpstreamExpressionPort.name shouldBe s"file://$rootPath/1st-workflow.cwl#compile/src"
@@ -97,7 +97,7 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
 
           nodes.collect {
             case c: PortBasedGraphOutputNode => c
-          }.map(_.name) shouldBe Set(s"file://$rootPath/1st-workflow.cwl#classout")
+          }.map(_.localName) shouldBe Set(s"file://$rootPath/1st-workflow.cwl#classout")
         case wth: Any => fail(s"Parsed unexpected Callable: $wth")
       }
     }
@@ -160,21 +160,21 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
     val graphInputNodes = nodes collect { case gin: GraphInputNode => gin }
     graphInputNodes should have size 1
     val patternInputNode = graphInputNodes.head
-    patternInputNode.name should be("pattern")
+    patternInputNode.localName should be("pattern")
 
-    nodes collect { case gon: GraphOutputNode => gon.name } should be(Set(
+    nodes collect { case gon: GraphOutputNode => gon.localName } should be(Set(
       "file:///Users/danb/wdl4s/r.cwl#cgrep-count",
       "file:///Users/danb/wdl4s/r.cwl#wc-count"
     ))
 
-    nodes collect { case cn: CallNode => cn.name } should be(Set("ps", "cgrep", "wc"))
+    nodes collect { case cn: CallNode => cn.localName } should be(Set("ps", "cgrep", "wc"))
 
-    val ps = nodes.collectFirst({ case ps: CallNode if ps.name == "ps" => ps }).get
-    val cgrep = nodes.collectFirst({ case cgrep: CallNode if cgrep.name == "cgrep" => cgrep }).get
-    val cgrepFileExpression = nodes.collectFirst({ case cgrepInput: ExpressionNode if cgrepInput.name == "file:///Users/danb/wdl4s/r.cwl#cgrep/file" => cgrepInput }).get
-    val cgrepPatternExpression = nodes.collectFirst({ case cgrepInput: ExpressionNode if cgrepInput.name == "file:///Users/danb/wdl4s/r.cwl#cgrep/pattern" => cgrepInput }).get
-    val wc = nodes.collectFirst({ case wc: CallNode if wc.name == "wc" => wc }).get
-    val wcFileExpression = nodes.collectFirst({ case wcInput: ExpressionNode if wcInput.name == "file:///Users/danb/wdl4s/r.cwl#wc/file" => wcInput }).get
+    val ps = nodes.collectFirst({ case ps: CallNode if ps.localName == "ps" => ps }).get
+    val cgrep = nodes.collectFirst({ case cgrep: CallNode if cgrep.localName == "cgrep" => cgrep }).get
+    val cgrepFileExpression = nodes.collectFirst({ case cgrepInput: ExpressionNode if cgrepInput.localName == "file:///Users/danb/wdl4s/r.cwl#cgrep/file" => cgrepInput }).get
+    val cgrepPatternExpression = nodes.collectFirst({ case cgrepInput: ExpressionNode if cgrepInput.localName == "file:///Users/danb/wdl4s/r.cwl#cgrep/pattern" => cgrepInput }).get
+    val wc = nodes.collectFirst({ case wc: CallNode if wc.localName == "wc" => wc }).get
+    val wcFileExpression = nodes.collectFirst({ case wcInput: ExpressionNode if wcInput.localName == "file:///Users/danb/wdl4s/r.cwl#wc/file" => wcInput }).get
 
     ps.upstream shouldBe empty
 

--- a/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
+++ b/cwl/src/test/scala/cwl/CwlWorkflowWomSpec.scala
@@ -80,12 +80,12 @@ class CwlWorkflowWomSpec extends FlatSpec with Matchers with TableDrivenProperty
           untarUpstream should have size 2
           untarUpstream.collectFirst({
             case exprNode: ExpressionNode if exprNode.name == s"file://$rootPath/1st-workflow.cwl#untar/extractfile" =>
-              exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode("ex", WdlStringType)
+              exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode(WomIdentifier("ex"), WdlStringType)
           }).getOrElse(fail("Can't find expression node for ex"))
           
           untarUpstream.collectFirst({
             case exprNode: ExpressionNode if exprNode.name == s"file://$rootPath/1st-workflow.cwl#untar/tarfile" =>
-              exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode("inp", WdlFileType)
+              exprNode.inputPorts.head.upstream.graphNode shouldBe RequiredGraphInputNode(WomIdentifier("inp"), WdlFileType)
           }).getOrElse(fail("Can't find expression node for inp"))
 
           val compileUpstreamExpressionPort = nodes.collectFirst {

--- a/wom/src/main/scala/wdl/Declaration.scala
+++ b/wom/src/main/scala/wdl/Declaration.scala
@@ -120,7 +120,7 @@ object Declaration {
       val womExpression = WdlWomExpression(wdlExpression, None)
       for {
         uninstantiatedExpression <- WdlWomExpression.findInputsforExpression(inputName, womExpression, localLookup, outerLookup)
-        expressionNode <- ExpressionNode.linkWithInputs(inputName, womExpression, uninstantiatedExpression.inputMapping)
+        expressionNode <- ExpressionNode.linkWithInputs(decl.womIdentifier, womExpression, uninstantiatedExpression.inputMapping)
       } yield IntermediateValueDeclarationNode(expressionNode)
     }
 
@@ -128,13 +128,13 @@ object Declaration {
       val womExpression = WdlWomExpression(wdlExpression, None)
       for {
         uninstantiatedExpression <- WdlWomExpression.findInputsforExpression(inputName, womExpression, localLookup, outerLookup)
-        graphOutputNode <- ExpressionBasedGraphOutputNode.linkWithInputs(inputName, womExpression, uninstantiatedExpression.inputMapping)
+        graphOutputNode <- ExpressionBasedGraphOutputNode.linkWithInputs(decl.womIdentifier, decl.wdlType, womExpression, uninstantiatedExpression.inputMapping)
       } yield GraphOutputDeclarationNode(graphOutputNode)
     }
 
     decl match {
-      case Declaration(opt: WdlOptionalType, _, None, _, _) => Valid(InputDeclarationNode(OptionalGraphInputNode(inputName, opt, decl.fullyQualifiedName)))
-      case Declaration(_, _, None, _, _) => Valid(InputDeclarationNode(RequiredGraphInputNode(inputName, decl.wdlType, decl.fullyQualifiedName)))
+      case Declaration(opt: WdlOptionalType, _, None, _, _) => Valid(InputDeclarationNode(OptionalGraphInputNode(decl.womIdentifier, opt)))
+      case Declaration(_, _, None, _, _) => Valid(InputDeclarationNode(RequiredGraphInputNode(decl.womIdentifier, decl.wdlType)))
       case Declaration(_, _, Some(expr), _, _) => declarationAsExpressionNode(expr)
       case WorkflowOutput(_, _, expr, _, _) => workflowOutputAsGraphOutputNode(expr)
     }

--- a/wom/src/main/scala/wdl/If.scala
+++ b/wom/src/main/scala/wdl/If.scala
@@ -6,11 +6,8 @@ import cats.syntax.validated._
 import lenthall.validation.ErrorOr._
 import wdl4s.parser.WdlParser.Ast
 import wdl.types.WdlBooleanType
-import wom.graph.GraphNodePort
-import wom.graph.Graph
 import wom.graph.ConditionalNode.ConditionalNodeWithNewNodes
-import wom.graph.ConditionalNode
-
+import wom.graph._
 /**
   * Represents an If block in WDL
   *
@@ -38,7 +35,7 @@ object If {
 
   def womConditionalNode(ifBlock: If, localLookup: Map[String, GraphNodePort.OutputPort]): ErrorOr[ConditionalNodeWithNewNodes] = {
     val ifConditionExpression = WdlWomExpression(ifBlock.condition, Option(ifBlock))
-    val ifConditionGraphInputExpressionValidation = WdlWomExpression.toExpressionNode("conditional", ifConditionExpression, localLookup, Map.empty)
+    val ifConditionGraphInputExpressionValidation = WdlWomExpression.toExpressionNode(WomIdentifier("conditional"), ifConditionExpression, localLookup, Map.empty)
     val ifConditionTypeValidation = ifConditionExpression.evaluateType(localLookup.map { case (k, v) => k -> v.womType }) flatMap {
       case WdlBooleanType => Valid(())
       case other => s"An if block must be given a boolean expression but instead got '${ifBlock.condition.toWdlString}' (a ${other.toWdlString})".invalidNel

--- a/wom/src/main/scala/wdl/Scatter.scala
+++ b/wom/src/main/scala/wdl/Scatter.scala
@@ -39,7 +39,7 @@ object Scatter {
     // Convert the scatter collection WdlExpression to a WdlWomExpression 
     val scatterCollectionExpression = WdlWomExpression(scatter.collection, Option(scatter))
     // Generate an ExpressionNode from the WdlWomExpression
-    val scatterCollectionExpressionNode = WdlWomExpression.toExpressionNode(scatter.item, scatterCollectionExpression, localLookup, Map.empty)
+    val scatterCollectionExpressionNode = WdlWomExpression.toExpressionNode(WomIdentifier(scatter.item), scatterCollectionExpression, localLookup, Map.empty)
     // Validate the collection evaluates to a traversable type
     val scatterItemTypeValidation = scatterCollectionExpression.evaluateType(localLookup.map { case (k, v) => k -> v.womType }) flatMap {
       case WdlArrayType(itemType) => Valid(itemType) // Covers maps because this is a custom unapply (see WdlArrayType)
@@ -50,7 +50,7 @@ object Scatter {
       _ <- scatterItemTypeValidation
       expressionNode <- scatterCollectionExpressionNode
       // Graph input node for the scatter variable in the inner graph
-      womInnerGraphScatterVariableInput = OuterGraphInputNode(scatter.item, expressionNode.singleExpressionOutputPort)
+      womInnerGraphScatterVariableInput = OuterGraphInputNode(WomIdentifier(scatter.item), expressionNode.singleExpressionOutputPort)
       g <- WdlGraphNode.buildWomGraph(scatter, Set(womInnerGraphScatterVariableInput), localLookup)
     } yield (g, womInnerGraphScatterVariableInput)
 

--- a/wom/src/main/scala/wdl/Scope.scala
+++ b/wom/src/main/scala/wdl/Scope.scala
@@ -108,10 +108,11 @@ trait Scope {
   }
   
   lazy val womIdentifier = {
-    // Limit the fully qualified name to the parent workflow, if it exists.
-    // The reason for this is if this scope comes from an imported namespace,
-    // the name of the namespace will be part of the FQN. While useful to construct the hierarchy and dependencies,
-    // this is not desirable when being used by underlying engines.
+    /* Limit the fully qualified name to the parent workflow, if it exists.
+     * The reason for this is if this scope comes from an imported namespace,
+     * the name of the namespace will be part of the FQN. While useful to construct the hierarchy and dependencies,
+     * this is not desirable when being used by underlying engines.
+    */
     val womFullyQualifiedName = ancestry.collectFirst {
       case workflow: WdlWorkflow => locallyQualifiedName(workflow)
     } getOrElse fullyQualifiedName

--- a/wom/src/main/scala/wdl/Scope.scala
+++ b/wom/src/main/scala/wdl/Scope.scala
@@ -6,6 +6,7 @@ import wdl.exception.{ScatterIndexNotFound, VariableLookupException, VariableNot
 import wdl.expression.WdlFunctions
 import wdl.values.WdlArray.WdlArrayLike
 import wdl.values.WdlValue
+import wom.graph.WomIdentifier
 
 import scala.util.{Failure, Success, Try}
 import scalax.collection.Graph
@@ -104,6 +105,18 @@ trait Scope {
     */
   lazy val fullyQualifiedName = {
     (ancestry.filter(_.appearsInFqn).map(_.unqualifiedName).reverse :+ unqualifiedName).mkString(".")
+  }
+  
+  lazy val womIdentifier = {
+    // Limit the fully qualified name to the parent workflow, if it exists.
+    // The reason for this is if this scope comes from an imported namespace,
+    // the name of the namespace will be part of the FQN. While useful to construct the hierarchy and dependencies,
+    // this is not desirable when being used by underlying engines.
+    val womFullyQualifiedName = ancestry.collectFirst {
+      case workflow: WdlWorkflow => locallyQualifiedName(workflow)
+    } getOrElse fullyQualifiedName
+
+    WomIdentifier(unqualifiedName, womFullyQualifiedName)
   }
 
   /**

--- a/wom/src/main/scala/wdl/TaskOutput.scala
+++ b/wom/src/main/scala/wdl/TaskOutput.scala
@@ -4,6 +4,7 @@ import wdl4s.parser.WdlParser.Ast
 import wdl.AstTools.EnhancedAstNode
 import wdl.types.WdlType
 import wom.callable.Callable.OutputDefinition
+import wom.graph._
 
 object TaskOutput {
   def apply(ast: Ast, syntaxErrorFormatter: WdlSyntaxErrorFormatter, parent: Option[Scope]): TaskOutput = {
@@ -14,7 +15,7 @@ object TaskOutput {
   }
 
   def buildWomOutputDefinition(taskOutput: TaskOutput) = {
-    OutputDefinition(taskOutput.unqualifiedName, taskOutput.wdlType, WdlWomExpression(taskOutput.requiredExpression, from = taskOutput.parent))
+    OutputDefinition(LocalName(taskOutput.unqualifiedName), taskOutput.wdlType, WdlWomExpression(taskOutput.requiredExpression, from = taskOutput.parent))
   }
 }
 

--- a/wom/src/main/scala/wdl/WdlExpression.scala
+++ b/wom/src/main/scala/wdl/WdlExpression.scala
@@ -203,7 +203,7 @@ case class WdlExpression(ast: AstNode) extends WdlValue {
   *             conditionals (wrapped in optionals) or scatters (wrapped in arrays).
   */
 final case class WdlWomExpression(wdlExpression: WdlExpression, from: Option[Scope]) extends WomExpression {
-
+  override def sourceString = wdlExpression.valueString
   override def inputs: Set[String] = wdlExpression.variableReferences map { _.fullVariableReferenceString } toSet
 
   override def evaluateValue(variableValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue] = {

--- a/wom/src/main/scala/wdl/WdlExpression.scala
+++ b/wom/src/main/scala/wdl/WdlExpression.scala
@@ -249,7 +249,7 @@ object WdlWomExpression {
         case (Some(port), None) => Valid(name -> port)
         case (None, Some(port)) => Valid(name -> OuterGraphInputNode(WomIdentifier(name), port).singleOutputPort)
         case (None, None) => s"No input $name found evaluating inputs for expression ${expression.wdlExpression.toWdlString}".invalidNel
-        case (Some(innerPort), Some(outerPort)) => s"Two inputs called '$name' found evaluating inputs for expression ${expression.wdlExpression.toWdlString}: on ${innerPort.graphNode.name} and ${outerPort.graphNode.name}".invalidNel
+        case (Some(innerPort), Some(outerPort)) => s"Two inputs called '$name' found evaluating inputs for expression ${expression.wdlExpression.toWdlString}: on ${innerPort.graphNode.localName} and ${outerPort.graphNode.localName}".invalidNel
       }
     }
 
@@ -264,7 +264,7 @@ object WdlWomExpression {
                        outerLookup: Map[String, GraphNodePort.OutputPort]) = {
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
     
-    findInputsforExpression(nodeIdentifier.localName.asString, expression, innerLookup, outerLookup) flatMap {
+    findInputsforExpression(nodeIdentifier.localName.value, expression, innerLookup, outerLookup) flatMap {
       case GraphNodeInputExpression(_, _, resolvedVariables) => 
         ExpressionNode.linkWithInputs(nodeIdentifier, expression, resolvedVariables)
     }

--- a/wom/src/main/scala/wdl/WdlExpression.scala
+++ b/wom/src/main/scala/wdl/WdlExpression.scala
@@ -247,7 +247,7 @@ object WdlWomExpression {
       val name = v.fullVariableReferenceString
       (innerLookup.get(name), outerLookup.get(name)) match {
         case (Some(port), None) => Valid(name -> port)
-        case (None, Some(port)) => Valid(name -> OuterGraphInputNode(name, port).singleOutputPort)
+        case (None, Some(port)) => Valid(name -> OuterGraphInputNode(WomIdentifier(name), port).singleOutputPort)
         case (None, None) => s"No input $name found evaluating inputs for expression ${expression.wdlExpression.toWdlString}".invalidNel
         case (Some(innerPort), Some(outerPort)) => s"Two inputs called '$name' found evaluating inputs for expression ${expression.wdlExpression.toWdlString}: on ${innerPort.graphNode.name} and ${outerPort.graphNode.name}".invalidNel
       }
@@ -258,15 +258,15 @@ object WdlWomExpression {
     } yield GraphNodeInputExpression(name, expression, resolvedVariables.toMap)
   }
   
-  def toExpressionNode(name: String,
+  def toExpressionNode(nodeIdentifier: WomIdentifier,
                        expression: WdlWomExpression,
                        innerLookup: Map[String, GraphNodePort.OutputPort],
                        outerLookup: Map[String, GraphNodePort.OutputPort]) = {
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
     
-    findInputsforExpression(name, expression, innerLookup, outerLookup) flatMap {
+    findInputsforExpression(nodeIdentifier.localName.asString, expression, innerLookup, outerLookup) flatMap {
       case GraphNodeInputExpression(_, _, resolvedVariables) => 
-        ExpressionNode.linkWithInputs(name, expression, resolvedVariables)
+        ExpressionNode.linkWithInputs(nodeIdentifier, expression, resolvedVariables)
     }
   }
 }

--- a/wom/src/main/scala/wdl/WdlGraphNode.scala
+++ b/wom/src/main/scala/wdl/WdlGraphNode.scala
@@ -78,18 +78,18 @@ object WdlGraphNode {
       // The output ports from the new node
       val newCallOutputPorts = (gnani.node.outputPorts map { p => s"$outputPortPrefix${p.name}" -> p }).toMap
       // The output ports from newly created GraphInputNodes:
-      val newInputOutputPorts = (gnani.newInputs map { i => i.name -> i.singleOutputPort }).toMap
+      val newInputOutputPorts = (gnani.newInputs map { i => i.localName -> i.singleOutputPort }).toMap
 
       FoldState(acc.nodes + gnani.node ++ gnani.newInputs ++ gnani.newExpressions, acc.availableInputs ++ newCallOutputPorts ++ newInputOutputPorts)
     }
 
     def buildNode(acc: FoldState, node: WdlGraphNode): ErrorOr[FoldState] = node match {
       case wdlCall: WdlCall => WdlCall.buildWomNodeAndInputs(wdlCall, acc.availableInputs, outerLookup) map { case cnani @ CallNodeAndNewNodes(call, _, _) =>
-        foldInGeneratedNodeAndNewInputs(acc, call.name + ".")(cnani)
+        foldInGeneratedNodeAndNewInputs(acc, call.localName + ".")(cnani)
       }
 
       case decl: DeclarationInterface => Declaration.buildWomNode(decl, acc.availableInputs, outerLookup) map { declNode =>
-        FoldState(acc.nodes + declNode.toGraphNode, acc.availableInputs ++ declNode.singleOutputPort.collect { case sop: OutputPort => declNode.toGraphNode.name -> sop })
+        FoldState(acc.nodes + declNode.toGraphNode, acc.availableInputs ++ declNode.singleOutputPort.collect { case sop: OutputPort => declNode.toGraphNode.localName -> sop })
       }
 
       case scatter: Scatter => Scatter.womScatterNode(scatter, acc.availableInputs) map { foldInGeneratedNodeAndNewInputs(acc, "")(_) }

--- a/wom/src/main/scala/wdl/WdlGraphNode.scala
+++ b/wom/src/main/scala/wdl/WdlGraphNode.scala
@@ -108,9 +108,16 @@ object WdlGraphNode {
 
     def withDefaultOutputs(g: Graph): Graph = if (g.nodes.exists(_.isInstanceOf[GraphOutputNode])) { g } else {
       Graph(g.nodes.union((g.nodes collect {
-          case node: CallNode => node.outputPorts.map(op => PortBasedGraphOutputNode(s"${node.name}.${op.name}", op.womType, op))
-          case node: ScatterNode => node.outputPorts.map(op => PortBasedGraphOutputNode(op.name, op.womType, op))
-          case node: ConditionalNode => node.outputPorts.map(op => PortBasedGraphOutputNode(op.name, op.womType, op))
+          case node: CallNode => node.outputPorts.map(op => {
+            val identifier = node.identifier.combine(op.name)
+            PortBasedGraphOutputNode(identifier, op.womType, op)
+          })
+          case node: ScatterNode => node.outputMapping.map(op => {
+            PortBasedGraphOutputNode(op.identifier, op.womType, op)
+          })
+          case node: ConditionalNode => node.conditionalOutputPorts.map(op => {
+            PortBasedGraphOutputNode(op.identifier, op.womType, op)
+          })
         }).flatten))
     }
 

--- a/wom/src/main/scala/wdl/WdlTask.scala
+++ b/wom/src/main/scala/wdl/WdlTask.scala
@@ -13,6 +13,7 @@ import wdl.util.StringUtil
 import wdl.values.{WdlFile, WdlValue}
 import wom.callable.Callable.{InputDefinitionWithDefault, OptionalInputDefinition, RequiredInputDefinition}
 import wom.callable.{Callable, TaskDefinition}
+import wom.graph.LocalName
 
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
@@ -223,10 +224,10 @@ case class WdlTask(name: String,
 
   private def buildWomInputs: List[Callable.InputDefinition] = declarations collect {
     case d if d.expression.isEmpty && !d.wdlType.isInstanceOf[WdlOptionalType] =>
-      RequiredInputDefinition(d.unqualifiedName, d.wdlType)
+      RequiredInputDefinition(LocalName(d.unqualifiedName), d.wdlType)
     case d if d.expression.isEmpty && d.wdlType.isInstanceOf[WdlOptionalType] =>
-      OptionalInputDefinition(d.unqualifiedName, d.wdlType.asInstanceOf[WdlOptionalType])
+      OptionalInputDefinition(LocalName(d.unqualifiedName), d.wdlType.asInstanceOf[WdlOptionalType])
     case d if d.expression.nonEmpty =>
-      InputDefinitionWithDefault(d.unqualifiedName, d.wdlType, WdlWomExpression(d.expression.get, Option(this)))
+      InputDefinitionWithDefault(LocalName(d.unqualifiedName), d.wdlType, WdlWomExpression(d.expression.get, Option(this)))
   } toList
 }

--- a/wom/src/main/scala/wdl/WorkflowInput.scala
+++ b/wom/src/main/scala/wdl/WorkflowInput.scala
@@ -1,9 +1,7 @@
 package wdl
 
 import wdl.types.{WdlOptionalType, WdlType}
-import wom.callable.Callable
 
 case class WorkflowInput(fqn: FullyQualifiedName, wdlType: WdlType) {
   val optional = wdlType.isInstanceOf[WdlOptionalType]
-  def toWom = Callable.RequiredInputDefinition(fqn, wdlType)
 }

--- a/wom/src/main/scala/wdl/command/WdlCommandPart.scala
+++ b/wom/src/main/scala/wdl/command/WdlCommandPart.scala
@@ -4,6 +4,7 @@ import wdl.expression.{WdlFunctions, WdlStandardLibraryFunctions}
 import wdl.values.WdlValue
 import wdl._
 import wom.CommandPart
+import wom.graph.LocalName
 import wom.expression.IoFunctionSet
 
 trait WdlCommandPart extends CommandPart {
@@ -12,10 +13,10 @@ trait WdlCommandPart extends CommandPart {
                   functions: WdlFunctions[WdlValue],
                   valueMapper: WdlValue => WdlValue): String
 
-  override def instantiate(inputsMap: Map[String, WdlValue],
+  override def instantiate(inputsMap: Map[LocalName, WdlValue],
                   functions: IoFunctionSet,
                   valueMapper: WdlValue => WdlValue): String = {
     val wdlFunctions = WdlStandardLibraryFunctions.fromIoFunctionSet(functions)
-    instantiate(Seq.empty, inputsMap, wdlFunctions, valueMapper)
+    instantiate(Seq.empty, inputsMap.map({case (localName, value) => localName.asString -> value}), wdlFunctions, valueMapper)
   }
 }

--- a/wom/src/main/scala/wdl/command/WdlCommandPart.scala
+++ b/wom/src/main/scala/wdl/command/WdlCommandPart.scala
@@ -17,6 +17,6 @@ trait WdlCommandPart extends CommandPart {
                   functions: IoFunctionSet,
                   valueMapper: WdlValue => WdlValue): String = {
     val wdlFunctions = WdlStandardLibraryFunctions.fromIoFunctionSet(functions)
-    instantiate(Seq.empty, inputsMap.map({case (localName, value) => localName.asString -> value}), wdlFunctions, valueMapper)
+    instantiate(Seq.empty, inputsMap.map({case (localName, value) => localName.value -> value}), wdlFunctions, valueMapper)
   }
 }

--- a/wom/src/main/scala/wdl/util/StringUtil.scala
+++ b/wom/src/main/scala/wdl/util/StringUtil.scala
@@ -33,7 +33,10 @@ object StringUtil {
   def normalize(s: String): String = {
     val trimmed = stripAll(s, "\r\n", "\r\n \t")
     val parts = trimmed.split("\\r?\\n")
-    val indent = parts.filterNot(_.trim.isEmpty).map(leadingWhitespaceCount).min
+    val indent = parts.filterNot(_.trim.isEmpty).map(leadingWhitespaceCount).toList match {
+      case Nil => 0
+      case nonEmpty => nonEmpty.min
+    }
     parts.map(_.drop(indent)).mkString("\n")
   }
 

--- a/wom/src/main/scala/wom/CommandPart.scala
+++ b/wom/src/main/scala/wom/CommandPart.scala
@@ -2,9 +2,10 @@ package wom
 
 import wdl.values.WdlValue
 import wom.expression.IoFunctionSet
+import wom.graph.LocalName
 
 trait CommandPart {
-  def instantiate(inputsMap: Map[String, WdlValue],
+  def instantiate(inputsMap: Map[LocalName, WdlValue],
                   functions: IoFunctionSet,
                   valueMapper: WdlValue => WdlValue): String
 }

--- a/wom/src/main/scala/wom/callable/Callable.scala
+++ b/wom/src/main/scala/wom/callable/Callable.scala
@@ -4,7 +4,7 @@ import lenthall.validation.ErrorOr.ErrorOr
 import wdl.types.{WdlOptionalType, WdlType}
 import wom.callable.Callable._
 import wom.expression.WomExpression
-import wom.graph.Graph
+import wom.graph.{Graph, LocalName}
 
 
 trait Callable {
@@ -16,13 +16,45 @@ trait Callable {
 
 object Callable {
   sealed trait InputDefinition {
-    def name: String
+    def localName: LocalName
     def womType: WdlType
+
+    /**
+      * Alias for localName.asString
+      */
+    def name = localName.asString
   }
 
-  final case class RequiredInputDefinition(name: String, womType: WdlType) extends InputDefinition
-  final case class InputDefinitionWithDefault(name: String, womType: WdlType, default: WomExpression) extends InputDefinition
-  final case class OptionalInputDefinition(name: String, womType: WdlOptionalType) extends InputDefinition
-  
-  final case class OutputDefinition(name: String, womType: WdlType, expression: WomExpression)
+  object RequiredInputDefinition {
+    def apply(name: String, womType: WdlType): RequiredInputDefinition = {
+      RequiredInputDefinition(LocalName(name), womType)
+    }
+  }
+  final case class RequiredInputDefinition(localName: LocalName, womType: WdlType) extends InputDefinition
+
+  object InputDefinitionWithDefault {
+    def apply(name: String, womType: WdlType, default: WomExpression): InputDefinitionWithDefault = {
+      InputDefinitionWithDefault(LocalName(name), womType, default)
+    }
+  }
+  final case class InputDefinitionWithDefault(localName: LocalName, womType: WdlType, default: WomExpression) extends InputDefinition
+
+  object OptionalInputDefinition {
+    def apply(name: String, womType: WdlOptionalType): OptionalInputDefinition = {
+      OptionalInputDefinition(LocalName(name), womType)
+    }
+  }
+  final case class OptionalInputDefinition(localName: LocalName, womType: WdlOptionalType) extends InputDefinition
+
+  object OutputDefinition {
+    def apply(name: String, womType: WdlType, expression: WomExpression): OutputDefinition = {
+      OutputDefinition(LocalName(name), womType, expression)
+    }
+  }
+  final case class OutputDefinition(localName: LocalName, womType: WdlType, expression: WomExpression) {
+    /**
+      * Alias for localName.asString
+      */
+    lazy val name = localName.asString
+  }
 }

--- a/wom/src/main/scala/wom/callable/Callable.scala
+++ b/wom/src/main/scala/wom/callable/Callable.scala
@@ -22,7 +22,7 @@ object Callable {
     /**
       * Alias for localName.asString
       */
-    def name = localName.asString
+    def name = localName.value
   }
 
   object RequiredInputDefinition {
@@ -55,6 +55,6 @@ object Callable {
     /**
       * Alias for localName.asString
       */
-    lazy val name = localName.asString
+    lazy val name = localName.value
   }
 }

--- a/wom/src/main/scala/wom/callable/TaskDefinition.scala
+++ b/wom/src/main/scala/wom/callable/TaskDefinition.scala
@@ -35,7 +35,7 @@ case class TaskDefinition(name: String,
                          functions: IoFunctionSet,
                          valueMapper: WdlValue => WdlValue = identity[WdlValue],
                          separate: Boolean = false): Try[String] = {
-    val mappedInputs = taskInputs.map({case (k, v) => k.name -> v})
+    val mappedInputs = taskInputs.map({case (k, v) => k.localName -> v})
     // TODO: Bring back inputs: Try(StringUtil.normalize(commandTemplate.map(_.instantiate(declarations, taskInputs, functions, valueMapper)).mkString("")))
     Try(StringUtil.normalize(commandTemplate.map(_.instantiate(mappedInputs, functions, valueMapper)).mkString(commandPartSeparator)))
   }

--- a/wom/src/main/scala/wom/callable/WorkflowDefinition.scala
+++ b/wom/src/main/scala/wom/callable/WorkflowDefinition.scala
@@ -1,10 +1,10 @@
 package wom.callable
 
-import lenthall.validation.ErrorOr.ErrorOr
-import wom.graph.{Graph, TaskCallNode}
 import cats.syntax.validated._
+import lenthall.validation.ErrorOr.ErrorOr
 import wom.expression.WomExpression
 import wom.graph.GraphNode._
+import wom.graph.{Graph, TaskCallNode}
 
 final case class WorkflowDefinition(name: String,
                                     innerGraph: Graph,

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -42,11 +42,11 @@ object Executable {
     */
   private def parseGraphInputs(graph: Graph, inputCoercionMap: Map[String, DelayedCoercionFunction]): ErrorOr[ResolvedExecutableInputs] = {
     def fromInputMapping(gin: ExternalGraphInputNode): Option[ErrorOr[ResolvedExecutableInput]] = {
-      inputCoercionMap.get(gin.identifier.fullyQualifiedName.asString).map(_(gin.womType).map(Coproduct[ResolvedExecutableInput](_)))
+      inputCoercionMap.get(gin.identifier.fullyQualifiedName.value).map(_(gin.womType).map(Coproduct[ResolvedExecutableInput](_)))
     }
 
     def fallBack(gin: ExternalGraphInputNode): ErrorOr[ResolvedExecutableInput] = gin match {
-      case required: RequiredGraphInputNode => s"Required workflow input '${required.identifier.fullyQualifiedName.asString}' not specified".invalidNel
+      case required: RequiredGraphInputNode => s"Required workflow input '${required.identifier.fullyQualifiedName.value}' not specified".invalidNel
       case optionalWithDefault: OptionalGraphInputNodeWithDefault => Coproduct[ResolvedExecutableInput](optionalWithDefault.default).validNel
       case optional: OptionalGraphInputNode => Coproduct[ResolvedExecutableInput](optional.womType.none: WdlValue).validNel
     }

--- a/wom/src/main/scala/wom/executable/Executable.scala
+++ b/wom/src/main/scala/wom/executable/Executable.scala
@@ -42,11 +42,11 @@ object Executable {
     */
   private def parseGraphInputs(graph: Graph, inputCoercionMap: Map[String, DelayedCoercionFunction]): ErrorOr[ResolvedExecutableInputs] = {
     def fromInputMapping(gin: ExternalGraphInputNode): Option[ErrorOr[ResolvedExecutableInput]] = {
-      inputCoercionMap.get(gin.fullyQualifiedIdentifier).map(_(gin.womType).map(Coproduct[ResolvedExecutableInput](_)))
+      inputCoercionMap.get(gin.identifier.fullyQualifiedName.asString).map(_(gin.womType).map(Coproduct[ResolvedExecutableInput](_)))
     }
 
     def fallBack(gin: ExternalGraphInputNode): ErrorOr[ResolvedExecutableInput] = gin match {
-      case required: RequiredGraphInputNode => s"Required workflow input '${required.fullyQualifiedIdentifier}' not specified".invalidNel
+      case required: RequiredGraphInputNode => s"Required workflow input '${required.identifier.fullyQualifiedName.asString}' not specified".invalidNel
       case optionalWithDefault: OptionalGraphInputNodeWithDefault => Coproduct[ResolvedExecutableInput](optionalWithDefault.default).validNel
       case optional: OptionalGraphInputNode => Coproduct[ResolvedExecutableInput](optional.womType.none: WdlValue).validNel
     }

--- a/wom/src/main/scala/wom/expression/WomExpression.scala
+++ b/wom/src/main/scala/wom/expression/WomExpression.scala
@@ -9,6 +9,7 @@ import scala.concurrent.Future
 import scala.util.Try
 
 trait WomExpression {
+  def sourceString: String
   def inputs: Set[String]
   def evaluateValue(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue]
   def evaluateType(inputTypes: Map[String, WdlType]): ErrorOr[WdlType]
@@ -16,6 +17,7 @@ trait WomExpression {
 }
 
 final case class PlaceholderWomExpression(inputs: Set[String], fixedWomType: WdlType) extends WomExpression {
+  override def sourceString: String = "placeholder"
   override def evaluateValue(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet): ErrorOr[WdlValue] = Valid(WdlString("42"))
   override def evaluateType(inputTypes: Map[String, WdlType]): ErrorOr[WdlType] = Valid(fixedWomType)
   override def evaluateFiles(inputValues: Map[String, WdlValue], ioFunctionSet: IoFunctionSet, coerceTo: WdlType): ErrorOr[Set[WdlFile]] = Valid(Set.empty)

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -21,7 +21,7 @@ sealed abstract class CallNode extends GraphNode {
   def inputDefinitionMappings: InputDefinitionMappings
 }
 
-final case class TaskCallNode private(override val name: String,
+final case class TaskCallNode private(override val identifier: WomIdentifier,
                                       callable: TaskDefinition,
                                       override val inputPorts: Set[GraphNodePort.InputPort],
                                       inputDefinitionMappings: InputDefinitionMappings) extends CallNode {
@@ -31,7 +31,7 @@ final case class TaskCallNode private(override val name: String,
   }
 }
 
-final case class WorkflowCallNode private(override val name: String,
+final case class WorkflowCallNode private(override val identifier: WomIdentifier,
                                           callable: WorkflowDefinition,
                                           override val inputPorts: Set[GraphNodePort.InputPort],
                                           inputDefinitionMappings: InputDefinitionMappings) extends CallNode {
@@ -43,17 +43,26 @@ final case class WorkflowCallNode private(override val name: String,
 
 object TaskCall {
   def graphFromDefinition(taskDefinition: TaskDefinition): ErrorOr[Graph] = {
-    def linkOutput(call: GraphNode)(output: OutputDefinition): ErrorOr[GraphNode] = call.outputByName(output.name).map(out => PortBasedGraphOutputNode(output.name, output.womType, out))
+    val taskDefinitionLocalName = LocalName(taskDefinition.name)
+    
+    // Creates an identifier for an input or an output
+    // The localName is the name of the input or output
+    // The FQN combines the name of the task to the name of the input or output
+    def identifier(name: String) = WomIdentifier(LocalName(name), taskDefinitionLocalName.combineToFullyQualifiedName(name))
+
+    def linkOutput(call: GraphNode)(output: OutputDefinition): ErrorOr[GraphNode] = call.outputByName(output.name).map(out => PortBasedGraphOutputNode(
+      identifier(output.name), output.womType, out
+    ))
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
 
     val callNodeBuilder = new CallNodeBuilder()
-
+    
     val inputDefinitionFold = taskDefinition.inputs.foldMap({ inputDef =>
     {
       val newNode = inputDef match {
-        case RequiredInputDefinition(name, womType) => RequiredGraphInputNode(name, womType)
-        case InputDefinitionWithDefault(name, womType, default) => OptionalGraphInputNodeWithDefault(name, womType, default)
-        case OptionalInputDefinition(name, womType) => OptionalGraphInputNode(name, womType)
+        case RequiredInputDefinition(name, womType) => RequiredGraphInputNode(identifier(name), womType)
+        case InputDefinitionWithDefault(name, womType, default) => OptionalGraphInputNodeWithDefault(identifier(name), womType, default)
+        case OptionalInputDefinition(name, womType) => OptionalGraphInputNode(identifier(name), womType)
       }
 
       InputDefinitionFold(
@@ -64,7 +73,8 @@ object TaskCall {
     }
     })(inputDefinitionFoldMonoid)
 
-    val callWithInputs = callNodeBuilder.build(taskDefinition.name, taskDefinition, inputDefinitionFold)
+    val uniqueIdentifier = WomIdentifier(taskDefinition.name)
+    val callWithInputs = callNodeBuilder.build(uniqueIdentifier, taskDefinition, inputDefinitionFold)
 
     for {
       outputs <- taskDefinition.outputs.traverse(linkOutput(callWithInputs.node) _)
@@ -106,12 +116,12 @@ object CallNode {
   /**
     * Don't use this directly; go via callWithInputs to make sure everything's in order when constructing a CallNode.
     */
-  private[graph] def apply(name: String,
+  private[graph] def apply(nodeIdentifier: WomIdentifier,
                            callable: Callable,
                            inputPorts: Set[GraphNodePort.InputPort],
                            inputDefinitionMappings: InputDefinitionMappings): CallNode = callable match {
-    case t: TaskDefinition => TaskCallNode(name, t, inputPorts, inputDefinitionMappings)
-    case w: WorkflowDefinition => WorkflowCallNode(name, w, inputPorts, inputDefinitionMappings)
+    case t: TaskDefinition => TaskCallNode(nodeIdentifier, t, inputPorts, inputDefinitionMappings)
+    case w: WorkflowDefinition => WorkflowCallNode(nodeIdentifier, w, inputPorts, inputDefinitionMappings)
   }
 
   /**
@@ -129,10 +139,10 @@ object CallNode {
       ConnectedInputPort(inputDefinition.name, inputDefinition.womType, outputPort, graphNodeSetter.get)
     }
 
-    def build(name: String,
+    def build(nodeIdentifier: WomIdentifier,
               callable: Callable,
               inputDefinitionFold: InputDefinitionFold): CallNodeAndNewNodes = {
-      val callNode = CallNode(name, callable, inputDefinitionFold.callInputPorts, inputDefinitionFold.mappings)
+      val callNode = CallNode(nodeIdentifier, callable, inputDefinitionFold.callInputPorts, inputDefinitionFold.mappings)
       graphNodeSetter._graphNode = callNode
       CallNodeAndNewNodes(callNode, inputDefinitionFold.newGraphInputNodes, inputDefinitionFold.newExpressionNodes)
     }

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -37,7 +37,7 @@ final case class WorkflowCallNode private(override val identifier: WomIdentifier
                                           inputDefinitionMappings: InputDefinitionMappings) extends CallNode {
   val callType: String = "workflow"
   override val outputPorts: Set[GraphNodePort.OutputPort] = {
-    callable.innerGraph.nodes.collect { case gon: GraphOutputNode => GraphNodeOutputPort(gon.name, gon.womType, this) }
+    callable.innerGraph.nodes.collect { case gon: GraphOutputNode => GraphNodeOutputPort(gon.localName, gon.womType, this) }
   }
 }
 

--- a/wom/src/main/scala/wom/graph/CallNode.scala
+++ b/wom/src/main/scala/wom/graph/CallNode.scala
@@ -48,10 +48,10 @@ object TaskCall {
     // Creates an identifier for an input or an output
     // The localName is the name of the input or output
     // The FQN combines the name of the task to the name of the input or output
-    def identifier(name: String) = WomIdentifier(LocalName(name), taskDefinitionLocalName.combineToFullyQualifiedName(name))
+    def identifier(name: LocalName) = WomIdentifier(name, taskDefinitionLocalName.combineToFullyQualifiedName(name))
 
     def linkOutput(call: GraphNode)(output: OutputDefinition): ErrorOr[GraphNode] = call.outputByName(output.name).map(out => PortBasedGraphOutputNode(
-      identifier(output.name), output.womType, out
+      identifier(output.localName), output.womType, out
     ))
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
 

--- a/wom/src/main/scala/wom/graph/ConditionalNode.scala
+++ b/wom/src/main/scala/wom/graph/ConditionalNode.scala
@@ -32,7 +32,7 @@ object ConditionalNode  {
     val graphNodeSetter = new GraphNode.GraphNodeSetter()
 
     val outputPorts: Set[ConditionalOutputPort] = innerGraph.nodes.collect { case gon: PortBasedGraphOutputNode =>
-      ConditionalOutputPort(gon.name, WdlOptionalType(gon.womType), gon, graphNodeSetter.get)
+      ConditionalOutputPort(WdlOptionalType(gon.womType), gon, graphNodeSetter.get)
     }
 
     val conditionalNode: ConditionalNode = ConditionalNode(innerGraph, expressionNode, outputPorts)

--- a/wom/src/main/scala/wom/graph/ConditionalNode.scala
+++ b/wom/src/main/scala/wom/graph/ConditionalNode.scala
@@ -15,7 +15,7 @@ final case class ConditionalNode private(innerGraph: Graph,
                                          condition: ExpressionNode,
                                          conditionalOutputPorts: Set[ConditionalOutputPort]) extends GraphNode {
 
-  override val name: String = "ConditionalNode"
+  override val identifier: WomIdentifier = WomIdentifier("ConditionalNode")
 
   override val inputPorts: Set[InputPort] = condition.inputPorts
   override val outputPorts: Set[GraphNodePort.OutputPort] = conditionalOutputPorts.toSet[OutputPort]

--- a/wom/src/main/scala/wom/graph/ExpressionNode.scala
+++ b/wom/src/main/scala/wom/graph/ExpressionNode.scala
@@ -7,7 +7,7 @@ import wom.expression.WomExpression
 import wom.graph.CallNode.InputDefinitionPointer
 import wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 
-final case class ExpressionNode(override val name: String, instantiatedExpression: InstantiatedExpression) extends GraphNode {
+final case class ExpressionNode(override val identifier: WomIdentifier, instantiatedExpression: InstantiatedExpression) extends GraphNode {
 
   val womType = instantiatedExpression.womReturnType
   val singleExpressionOutputPort = GraphNodeOutputPort(name, womType, this)
@@ -19,6 +19,6 @@ final case class ExpressionNode(override val name: String, instantiatedExpressio
 }
 
 object ExpressionNode {
-  def linkWithInputs(name: String, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionNode] =
-    InstantiatedExpression.instantiateExpressionForNode(ExpressionNode.apply)(name, expression, inputMapping)
+  def linkWithInputs(nodeIdentifier: WomIdentifier, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionNode] =
+    InstantiatedExpression.instantiateExpressionForNode(ExpressionNode.apply)(nodeIdentifier, expression, inputMapping)
 }

--- a/wom/src/main/scala/wom/graph/ExpressionNode.scala
+++ b/wom/src/main/scala/wom/graph/ExpressionNode.scala
@@ -10,7 +10,7 @@ import wom.graph.GraphNodePort.{GraphNodeOutputPort, OutputPort}
 final case class ExpressionNode(override val identifier: WomIdentifier, instantiatedExpression: InstantiatedExpression) extends GraphNode {
 
   val womType = instantiatedExpression.womReturnType
-  val singleExpressionOutputPort = GraphNodeOutputPort(name, womType, this)
+  val singleExpressionOutputPort = GraphNodeOutputPort(localName, womType, this)
 
   lazy val inputDefinitionPointer = Coproduct[InputDefinitionPointer](singleExpressionOutputPort: OutputPort)
 

--- a/wom/src/main/scala/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wom/graph/Graph.scala
@@ -61,6 +61,11 @@ object Graph {
 
     // from https://stackoverflow.com/a/24729587/1498572
     def fqnUniqueness: ErrorOr[Unit] = nodes
+      .collect({
+        case callNode: CallNode => callNode
+        case gin: GraphInputNode => gin
+        case gon: GraphOutputNode => gon
+      })  
       .toList // Important since nodes is a Set, we don't want duplicates to disappear automatically when mapping to FQN
       .map(_.identifier.fullyQualifiedName)
       .groupBy(identity)

--- a/wom/src/main/scala/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wom/graph/Graph.scala
@@ -59,6 +59,7 @@ object Graph {
       node.inputPorts.toList.traverse(goodLink).void
     }
 
+    // from https://stackoverflow.com/a/24729587/1498572
     def fqnUniqueness: ErrorOr[Unit] = nodes
       .toList // Important since nodes is a Set, we don't want duplicates to disappear automatically when mapping to FQN
       .map(_.identifier.fullyQualifiedName)

--- a/wom/src/main/scala/wom/graph/Graph.scala
+++ b/wom/src/main/scala/wom/graph/Graph.scala
@@ -23,7 +23,7 @@ final case class Graph private(nodes: Set[GraphNode]) {
   lazy val calls: Set[CallNode] = nodes.filterByType[CallNode]
   lazy val scatters: Set[ScatterNode] = nodes.filterByType[ScatterNode]
 
-  def outputByName(name: String): Option[GraphOutputNode] = outputNodes.find(_.name == name)
+  def outputByName(name: String): Option[GraphOutputNode] = outputNodes.find(_.localName == name)
 }
 
 object Graph {
@@ -40,7 +40,7 @@ object Graph {
 
     def upstreamNodeInGraph(port: InputPort): ErrorOr[Unit] = {
       val upstreamOutputPort = port.upstream
-      boolToErrorOr(nodes.exists(_ eq upstreamOutputPort.graphNode), s"The input link ${port.name} on ${port.graphNode.name} is linked to a node outside the graph set (${upstreamOutputPort.name})")
+      boolToErrorOr(nodes.exists(_ eq upstreamOutputPort.graphNode), s"The input link ${port.name} on ${port.graphNode.localName} is linked to a node outside the graph set (${upstreamOutputPort.name})")
     }
 
     def portProperlyEmbedded(port: GraphNodePort, portFinder: GraphNode => Set[_ <: GraphNodePort]): ErrorOr[Unit] = {
@@ -74,7 +74,7 @@ object Graph {
       }).toList match {
       case Nil => ().validNel
       case head :: tail =>
-        NonEmptyList.of(head, tail: _*).map(fqn => s"Two or more nodes have the same FullyQualifiedName: ${fqn.asString}").invalid
+        NonEmptyList.of(head, tail: _*).map(fqn => s"Two or more nodes have the same FullyQualifiedName: ${fqn.value}").invalid
     }
 
     (fqnUniqueness, nodes.toList.traverse(validateNode)) mapN { case (_, _) =>

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -37,7 +37,7 @@ sealed trait ExternalGraphInputNode extends GraphInputNode {
     * 
     */
   
-  override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(identifier.fullyQualifiedName.asString, womType, this)
+  override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(identifier, womType, this)
 }
 
 final case class RequiredGraphInputNode(override val identifier: WomIdentifier,

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -6,7 +6,7 @@ import wom.graph.GraphNodePort.GraphNodeOutputPort
 
 sealed trait GraphInputNode extends GraphNode {
   def womType: WdlType
-  lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(name, womType, this)
+  lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(localName, womType, this)
 
   override val inputPorts: Set[GraphNodePort.InputPort] = Set.empty
   override val outputPorts: Set[GraphNodePort.OutputPort] = Set(singleOutputPort)

--- a/wom/src/main/scala/wom/graph/GraphInputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphInputNode.scala
@@ -14,7 +14,7 @@ sealed trait GraphInputNode extends GraphNode {
 
 sealed trait ExternalGraphInputNode extends GraphInputNode {
   /**
-    * The idea is this value should be the same as the one we expect the key in the input file to have.
+    * The fully qualified name should be the same as the one we expect the key in the input file to have.
     * e.g in WDL:
     * workflow.wdl:
     *   workflow w {
@@ -36,46 +36,24 @@ sealed trait ExternalGraphInputNode extends GraphInputNode {
     *   s: "hi !"
     * 
     */
-  def fullyQualifiedIdentifier: String
   
-  override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(fullyQualifiedIdentifier, womType, this)
+  override lazy val singleOutputPort: GraphNodeOutputPort = GraphNodeOutputPort(identifier.fullyQualifiedName.asString, womType, this)
 }
 
-object RequiredGraphInputNode {
-  def apply(name: String, womType: WdlType): RequiredGraphInputNode = {
-    RequiredGraphInputNode(name, womType, name)
-  }
-}
+final case class RequiredGraphInputNode(override val identifier: WomIdentifier,
+                                        womType: WdlType) extends ExternalGraphInputNode
 
-final case class RequiredGraphInputNode(override val name: String,
-                                        womType: WdlType,
-                                        fullyQualifiedIdentifier: String) extends ExternalGraphInputNode
-
-object OptionalGraphInputNode {
-  def apply(name: String, womType: WdlOptionalType): OptionalGraphInputNode = {
-    OptionalGraphInputNode(name, womType, name)
-  }
-}
-
-final case class OptionalGraphInputNode(override val name: String,
-                                        womType: WdlOptionalType,
-                                        fullyQualifiedIdentifier: String) extends ExternalGraphInputNode
-
-object OptionalGraphInputNodeWithDefault {
-  def apply(name: String, womType: WdlType, default: WomExpression): OptionalGraphInputNodeWithDefault = {
-    OptionalGraphInputNodeWithDefault(name, womType, default, name)
-  }
-}
+final case class OptionalGraphInputNode(override val identifier: WomIdentifier,
+                                        womType: WdlOptionalType) extends ExternalGraphInputNode
 
 // If we want to allow defaults to be "complex" expressions with dependencies we may need to make it an InstantiatedExpression here instead
-final case class OptionalGraphInputNodeWithDefault(override val name: String,
+final case class OptionalGraphInputNodeWithDefault(override val identifier: WomIdentifier,
                                                    womType: WdlType,
-                                                   default: WomExpression,
-                                                   fullyQualifiedIdentifier: String) extends ExternalGraphInputNode
+                                                   default: WomExpression) extends ExternalGraphInputNode
 
 /**
   * Used to represent an input to any GraphNode's inner graph which is a link to a value somewhere in the outer graph.
   */
-final case class OuterGraphInputNode(override val name: String, linkToOuterGraph: GraphNodePort.OutputPort) extends GraphInputNode {
+final case class OuterGraphInputNode(override val identifier: WomIdentifier, linkToOuterGraph: GraphNodePort.OutputPort) extends GraphInputNode {
   override def womType: WdlType = linkToOuterGraph.womType
 }

--- a/wom/src/main/scala/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphNode.scala
@@ -1,15 +1,19 @@
 package wom.graph
 
-import lenthall.validation.ErrorOr.ErrorOr
-import wom.graph.GraphNode._
-import wom.graph.GraphNodePort.{ConnectedInputPort, InputPort, OutputPort}
 import cats.implicits._
+import lenthall.validation.ErrorOr.ErrorOr
 import wom.callable.Callable
-import wom.callable.Callable.{OptionalInputDefinition, InputDefinitionWithDefault, RequiredInputDefinition}
+import wom.callable.Callable.RequiredInputDefinition
+import wom.graph.GraphNode._
+import wom.graph.GraphNodePort.InputPort
 
 trait GraphNode {
+  def identifier: WomIdentifier
 
-  def name: String
+  /**
+    * Alias for identifier.localName.asString
+    */
+  final def name: String = identifier.localName.asString
 
   /**
     * Inputs that must be available before this graph node can be run.
@@ -60,37 +64,6 @@ object GraphNode {
     var _graphNode: GraphNode = _
     private def getGraphNode = _graphNode
     def get: Unit => GraphNode = _ => getGraphNode
-  }
-
-  private[graph] case class LinkedInputPort(newInputPort: InputPort, newGraphInput: Option[GraphInputNode])
-
-  /**
-    * Attempts to create an InputPort from the input definition, linked to one of the inputMapping entries.
-    * If it fails to find an appropriate input, it will create a new GraphInputNode instead.
-    * @param inputPrefix If the input port should have a prefix to its name as well as the inputDefinition's name.
-    * @param inputMapping Set of inputs available to this linker.
-    * @param callNodeRef We construct the input port with a lazy GraphNode reference. At some point this function
-    *                    will be called by the new InputPort to link to its parent GraphNode.
-    *                    (we do this because the GraphNode might not be constructed yet, since it itself needs a set
-    *                    of InputPorts for construction, and that's what we're making here...)
-    * @param inputDefinition The input to create an input port for.
-    * @return The new input port, and a GraphInputNode if we needed to make one. Wrapped in a case class.
-    */
-  private[graph] def linkInputPort(inputPrefix: String, inputMapping: Map[String, OutputPort], callNodeRef: Unit => GraphNode)(inputDefinition: Callable.InputDefinition): LinkedInputPort = {
-    val (outputPort, graphNode): (OutputPort, Option[GraphInputNode]) = inputDefinition match {
-      case input if inputMapping.contains(input.name) => (inputMapping(input.name), None)
-      case RequiredInputDefinition(n, womType) =>
-        val result = RequiredGraphInputNode(s"$inputPrefix$n", womType)
-        (result.singleOutputPort, Option(result)) // Read: Some(result)
-      case OptionalInputDefinition(n, womType) =>
-        val result = OptionalGraphInputNode(s"$inputPrefix$n", womType)
-        (result.singleOutputPort, Option(result)) // Read: Some(result)
-      case InputDefinitionWithDefault(n, womType, default) =>
-        val result = OptionalGraphInputNodeWithDefault(s"$inputPrefix$n", womType, default)
-        (result.singleOutputPort, Option(result)) // Read: Some(result)
-    }
-
-    LinkedInputPort(ConnectedInputPort(inputDefinition.name, inputDefinition.womType, outputPort, callNodeRef), graphNode)
   }
 
   private[wom] implicit class EnhancedGraphNodeSet(val nodes: Set[GraphNode]) extends AnyVal {

--- a/wom/src/main/scala/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphNode.scala
@@ -72,7 +72,7 @@ object GraphNode {
       */
     def inputDefinitions: Set[_ <: Callable.InputDefinition] = nodes collect {
       // TODO: FIXME: They might not be required!!
-      case gin: GraphInputNode => RequiredInputDefinition(gin.name, gin.womType)
+      case gin: GraphInputNode => RequiredInputDefinition(gin.identifier.localName, gin.womType)
     }
   }
 

--- a/wom/src/main/scala/wom/graph/GraphNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphNode.scala
@@ -11,9 +11,14 @@ trait GraphNode {
   def identifier: WomIdentifier
 
   /**
-    * Alias for identifier.localName.asString
+    * Alias for identifier.localName.value
     */
-  final def name: String = identifier.localName.asString
+  final def localName: String = identifier.localName.value
+
+  /**
+    * Alias for identifier.fullyQualifiedName.value
+    */
+  final def fullyQualifiedName: String = identifier.fullyQualifiedName.value
 
   /**
     * Inputs that must be available before this graph node can be run.

--- a/wom/src/main/scala/wom/graph/GraphNodePort.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodePort.scala
@@ -21,7 +21,7 @@ object GraphNodePort {
   }
 
   sealed trait OutputPort extends GraphNodePort {
-
+    def identifier: WomIdentifier = graphNode.identifier.combine(name)
     // TODO: Might end up wanting a backwards link to the InputPorts that use this (eg def downstream: Set[InputPort])?
   }
 
@@ -44,10 +44,14 @@ object GraphNodePort {
   /**
     * Represents the gathered output from a call/declaration in a ScatterNode.
     */
-  final case class ScatterGathererPort(name: String, womType: WdlArrayType, outputToGather: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort
+  final case class ScatterGathererPort(name: String, womType: WdlArrayType, outputToGather: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
+    override def identifier: WomIdentifier = outputToGather.identifier
+  }
 
   /**
     * Represents the conditional output from a call or declaration in a ConditionalNode
     */
-  final case class ConditionalOutputPort(name: String, womType: WdlOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort
+  final case class ConditionalOutputPort(name: String, womType: WdlOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
+    override def identifier: WomIdentifier = outputToExpose.identifier
+  }
 }

--- a/wom/src/main/scala/wom/graph/GraphNodePort.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodePort.scala
@@ -21,6 +21,7 @@ object GraphNodePort {
   }
 
   sealed trait OutputPort extends GraphNodePort {
+    // In general we can just combine the graphNode identifier to the output port name to get an identifier here
     def identifier: WomIdentifier = graphNode.identifier.combine(name)
     // TODO: Might end up wanting a backwards link to the InputPorts that use this (eg def downstream: Set[InputPort])?
   }
@@ -45,6 +46,7 @@ object GraphNodePort {
     * Represents the gathered output from a call/declaration in a ScatterNode.
     */
   final case class ScatterGathererPort(name: String, womType: WdlArrayType, outputToGather: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
+    // Since this port just wraps a PortBasedGraphOutputNode which itself wraps an output port, we can re-use the same identifier
     override def identifier: WomIdentifier = outputToGather.identifier
   }
 
@@ -52,6 +54,7 @@ object GraphNodePort {
     * Represents the conditional output from a call or declaration in a ConditionalNode
     */
   final case class ConditionalOutputPort(name: String, womType: WdlOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
+    // Since this port just wraps a PortBasedGraphOutputNode which itself wraps an output port, we can re-use the same identifier
     override def identifier: WomIdentifier = outputToExpose.identifier
   }
 }

--- a/wom/src/main/scala/wom/graph/GraphNodePort.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodePort.scala
@@ -21,8 +21,12 @@ object GraphNodePort {
   }
 
   sealed trait OutputPort extends GraphNodePort {
-    // In general we can just combine the graphNode identifier to the output port name to get an identifier here
-    def identifier: WomIdentifier = graphNode.identifier.combine(name)
+    def identifier: WomIdentifier
+
+    /**
+      * Alias for identifier.localName.asString
+      */
+    override def name = identifier.localName.asString
     // TODO: Might end up wanting a backwards link to the InputPorts that use this (eg def downstream: Set[InputPort])?
   }
 
@@ -40,12 +44,17 @@ object GraphNodePort {
   /**
     * For any graph node that uses a declarations to produce outputs (e.g. call, declaration):
     */
-  final case class GraphNodeOutputPort(name: String, womType: WdlType, graphNode: GraphNode) extends OutputPort
+  object GraphNodeOutputPort {
+    def apply(name: String, womType: WdlType, graphNode: GraphNode): GraphNodeOutputPort = {
+      GraphNodeOutputPort(WomIdentifier(LocalName(name), graphNode.identifier.fullyQualifiedName.combine(name)), womType, graphNode)
+    }
+  }
+  case class GraphNodeOutputPort(override val identifier: WomIdentifier, womType: WdlType, graphNode: GraphNode) extends OutputPort
 
   /**
     * Represents the gathered output from a call/declaration in a ScatterNode.
     */
-  final case class ScatterGathererPort(name: String, womType: WdlArrayType, outputToGather: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
+  final case class ScatterGathererPort(womType: WdlArrayType, outputToGather: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
     // Since this port just wraps a PortBasedGraphOutputNode which itself wraps an output port, we can re-use the same identifier
     override def identifier: WomIdentifier = outputToGather.identifier
   }
@@ -53,7 +62,7 @@ object GraphNodePort {
   /**
     * Represents the conditional output from a call or declaration in a ConditionalNode
     */
-  final case class ConditionalOutputPort(name: String, womType: WdlOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
+  final case class ConditionalOutputPort(womType: WdlOptionalType, outputToExpose: PortBasedGraphOutputNode, g: Unit => GraphNode) extends OutputPort with DelayedGraphNodePort {
     // Since this port just wraps a PortBasedGraphOutputNode which itself wraps an output port, we can re-use the same identifier
     override def identifier: WomIdentifier = outputToExpose.identifier
   }

--- a/wom/src/main/scala/wom/graph/GraphNodePort.scala
+++ b/wom/src/main/scala/wom/graph/GraphNodePort.scala
@@ -26,7 +26,7 @@ object GraphNodePort {
     /**
       * Alias for identifier.localName.asString
       */
-    override def name = identifier.localName.asString
+    override def name = identifier.localName.value
     // TODO: Might end up wanting a backwards link to the InputPorts that use this (eg def downstream: Set[InputPort])?
   }
 

--- a/wom/src/main/scala/wom/graph/GraphOutputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphOutputNode.scala
@@ -25,7 +25,7 @@ final case class PortBasedGraphOutputNode(override val identifier: WomIdentifier
   */
 final case class ExpressionBasedGraphOutputNode private(override val identifier: WomIdentifier, womType: WdlType, instantiatedExpression: InstantiatedExpression) extends GraphOutputNode {
   override val inputPorts = instantiatedExpression.inputPorts
-  val singleOutputPort = GraphNodeOutputPort(identifier.localName.asString, womType, this)
+  val singleOutputPort = GraphNodeOutputPort(identifier, womType, this)
   override val outputPorts: Set[GraphNodePort.OutputPort] = Set(singleOutputPort)
 }
 

--- a/wom/src/main/scala/wom/graph/GraphOutputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphOutputNode.scala
@@ -13,7 +13,7 @@ sealed trait GraphOutputNode extends GraphNode {
   * Exposes an existing output port as a graph output.
   */
 final case class PortBasedGraphOutputNode(override val identifier: WomIdentifier, womType: WdlType, source: OutputPort) extends GraphOutputNode {
-  val singleInputPort = ConnectedInputPort(name, womType, source, _ => this)
+  val singleInputPort = ConnectedInputPort(localName, womType, source, _ => this)
   override val inputPorts: Set[GraphNodePort.InputPort] = Set(singleInputPort)
   override val outputPorts: Set[GraphNodePort.OutputPort] = Set(source)
 }

--- a/wom/src/main/scala/wom/graph/GraphOutputNode.scala
+++ b/wom/src/main/scala/wom/graph/GraphOutputNode.scala
@@ -3,20 +3,19 @@ package wom.graph
 import lenthall.validation.ErrorOr.ErrorOr
 import wdl.types.WdlType
 import wom.expression.WomExpression
-import wom.graph.GraphNodePort.{ConnectedInputPort, OutputPort}
+import wom.graph.GraphNodePort.{ConnectedInputPort, GraphNodeOutputPort, OutputPort}
 
 sealed trait GraphOutputNode extends GraphNode {
   def womType: WdlType
-
-  final override val outputPorts: Set[GraphNodePort.OutputPort] = Set.empty
 }
 
 /**
   * Exposes an existing output port as a graph output.
   */
-final case class PortBasedGraphOutputNode(override val name: String, womType: WdlType, source: OutputPort) extends GraphOutputNode {
+final case class PortBasedGraphOutputNode(override val identifier: WomIdentifier, womType: WdlType, source: OutputPort) extends GraphOutputNode {
   val singleInputPort = ConnectedInputPort(name, womType, source, _ => this)
   override val inputPorts: Set[GraphNodePort.InputPort] = Set(singleInputPort)
+  override val outputPorts: Set[GraphNodePort.OutputPort] = Set(source)
 }
 
 /**
@@ -24,13 +23,17 @@ final case class PortBasedGraphOutputNode(override val name: String, womType: Wd
   *
   * NB: Construct this via ExpressionBasedGraphOutputNode.linkWithInputs(...)
   */
-final case class ExpressionBasedGraphOutputNode private(override val name: String, instantiatedExpression: InstantiatedExpression) extends GraphOutputNode {
-  override val womType = instantiatedExpression.womReturnType
+final case class ExpressionBasedGraphOutputNode private(override val identifier: WomIdentifier, womType: WdlType, instantiatedExpression: InstantiatedExpression) extends GraphOutputNode {
   override val inputPorts = instantiatedExpression.inputPorts
+  val singleOutputPort = GraphNodeOutputPort(identifier.localName.asString, womType, this)
+  override val outputPorts: Set[GraphNodePort.OutputPort] = Set(singleOutputPort)
 }
 
 object ExpressionBasedGraphOutputNode {
-  def linkWithInputs(name: String, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionBasedGraphOutputNode] =
-    InstantiatedExpression.instantiateExpressionForNode(ExpressionBasedGraphOutputNode.apply)(name, expression, inputMapping)
+  def linkWithInputs(nodeIdentifier: WomIdentifier, womType: WdlType, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionBasedGraphOutputNode] = {
+    val nodeConstructor = (identifier: WomIdentifier, instantiatedExpression: InstantiatedExpression) => {
+      ExpressionBasedGraphOutputNode(identifier, womType, instantiatedExpression)
+    }
+    InstantiatedExpression.instantiateExpressionForNode(nodeConstructor)(nodeIdentifier, expression, inputMapping)
+  }
 }
-

--- a/wom/src/main/scala/wom/graph/InstantiatedExpression.scala
+++ b/wom/src/main/scala/wom/graph/InstantiatedExpression.scala
@@ -15,12 +15,12 @@ class InstantiatedExpression private(val expression: WomExpression, val womRetur
 
 object InstantiatedExpression {
 
-  private[graph] def instantiateExpressionForNode[ExpressionBasedNode <: GraphNode](nodeConstructor: (String, InstantiatedExpression) => ExpressionBasedNode)(name: String, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionBasedNode] = {
+  private[graph] def instantiateExpressionForNode[ExpressionBasedNode <: GraphNode, Identifier <: WomIdentifier](nodeConstructor: (Identifier, InstantiatedExpression) => ExpressionBasedNode)(nodeIdentifier: Identifier, expression: WomExpression, inputMapping: Map[String, OutputPort]): ErrorOr[ExpressionBasedNode] = {
     val graphNodeSetter = new GraphNode.GraphNodeSetter()
 
     for {
       linkedInputs <- InstantiatedExpression.linkWithInputs(graphNodeSetter, expression, inputMapping)
-      expressionNode = nodeConstructor(name, linkedInputs)
+      expressionNode = nodeConstructor(nodeIdentifier, linkedInputs)
       _ = graphNodeSetter._graphNode = expressionNode
     } yield expressionNode
   }

--- a/wom/src/main/scala/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wom/graph/ScatterNode.scala
@@ -16,7 +16,7 @@ final case class ScatterNode private(innerGraph: Graph,
                                      scatterVariableInnerGraphInputNode: GraphInputNode,
                                      outputMapping: Set[ScatterGathererPort]) extends GraphNode {
 
-  override val name: String = "ScatterNode"
+  override val identifier: WomIdentifier = WomIdentifier("ScatterNode")
 
   // NB if you find yourself calling .filter on this set of inputPorts, you probably just wanted to access either
   // the scatterVariableMapping or otherInputPorts fields directly.

--- a/wom/src/main/scala/wom/graph/ScatterNode.scala
+++ b/wom/src/main/scala/wom/graph/ScatterNode.scala
@@ -49,7 +49,7 @@ object ScatterNode {
     val graphNodeSetter = new GraphNode.GraphNodeSetter()
 
     val outputPorts: Set[ScatterGathererPort] = innerGraph.nodes.collect { case gon: PortBasedGraphOutputNode =>
-      ScatterGathererPort(gon.name, WdlArrayType(gon.womType), gon, graphNodeSetter.get)
+      ScatterGathererPort(WdlArrayType(gon.womType), gon, graphNodeSetter.get)
     }
 
     val scatterNode = ScatterNode(

--- a/wom/src/main/scala/wom/graph/WomIdentifier.scala
+++ b/wom/src/main/scala/wom/graph/WomIdentifier.scala
@@ -7,7 +7,8 @@ package wom.graph
 case class LocalName(private val value: String) {
   def asString: String = value
   def combineToLocalName(other: String) = LocalName(s"$value.$other")
-  def combineToFullyQualifiedName(other: String) = FullyQualifiedName(s"$value.$other")
+  def combineToFullyQualifiedName(other: String): FullyQualifiedName = FullyQualifiedName(s"$value.$other")
+  def combineToFullyQualifiedName(other: LocalName): FullyQualifiedName = combineToFullyQualifiedName(other.asString)
 }
 
 /**
@@ -28,6 +29,7 @@ object WomIdentifier {
 }
 
 case class WomIdentifier(localName: LocalName, fullyQualifiedName: FullyQualifiedName) {
+  def combine(other: LocalName): WomIdentifier = combine(other.asString)
   def combine(other: String): WomIdentifier = {
     WomIdentifier(localName.combineToLocalName(other), fullyQualifiedName.combine(other))
   }

--- a/wom/src/main/scala/wom/graph/WomIdentifier.scala
+++ b/wom/src/main/scala/wom/graph/WomIdentifier.scala
@@ -4,11 +4,10 @@ package wom.graph
   * Identifies a node in its local context.
   * Used in during graph construction to link nodes together and validate the graph.
   */
-case class LocalName(private val value: String) {
-  def asString: String = value
+case class LocalName(value: String) {
   def combineToLocalName(other: String) = LocalName(s"$value.$other")
   def combineToFullyQualifiedName(other: String): FullyQualifiedName = FullyQualifiedName(s"$value.$other")
-  def combineToFullyQualifiedName(other: LocalName): FullyQualifiedName = combineToFullyQualifiedName(other.asString)
+  def combineToFullyQualifiedName(other: LocalName): FullyQualifiedName = combineToFullyQualifiedName(other.value)
 }
 
 /**
@@ -19,8 +18,7 @@ case class LocalName(private val value: String) {
   * It is not required by WOM strictly speaking but rather useful to implementations
   * for serializing or reporting.
   */
-case class FullyQualifiedName(private val value: String) {
-  def asString: String = value
+case class FullyQualifiedName(value: String) {
   def combine(other: String) = FullyQualifiedName(s"$value.$other")
 }
 
@@ -30,7 +28,7 @@ object WomIdentifier {
 }
 
 case class WomIdentifier(localName: LocalName, fullyQualifiedName: FullyQualifiedName) {
-  def combine(other: LocalName): WomIdentifier = combine(other.asString)
+  def combine(other: LocalName): WomIdentifier = combine(other.value)
   def combine(other: String): WomIdentifier = {
     WomIdentifier(localName.combineToLocalName(other), fullyQualifiedName.combine(other))
   }

--- a/wom/src/main/scala/wom/graph/WomIdentifier.scala
+++ b/wom/src/main/scala/wom/graph/WomIdentifier.scala
@@ -1,0 +1,34 @@
+package wom.graph
+
+/**
+  * Identifies a node in its local context.
+  * Used in during graph construction to link nodes together and validate the graph.
+  */
+case class LocalName(private val value: String) {
+  def asString: String = value
+  def combineToLocalName(other: String) = LocalName(s"$value.$other")
+  def combineToFullyQualifiedName(other: String) = FullyQualifiedName(s"$value.$other")
+}
+
+/**
+  * Identifies a node uniquely in its graph.
+  * This *can* be the same as local name.
+  * It is not required by WOM strictly speaking but rather useful to implementations
+  * for serializing or reporting.
+  * A graph will fail to construct if two or more nodes share the same FullyQualifiedName
+  */
+case class FullyQualifiedName(private val value: String) {
+  def asString: String = value
+  def combine(other: String) = FullyQualifiedName(s"$value.$other")
+}
+
+object WomIdentifier {
+  def apply(localName: String): WomIdentifier = WomIdentifier(LocalName(localName), FullyQualifiedName(localName))
+  def apply(localName: String, fullyQualifiedName: String): WomIdentifier = WomIdentifier(LocalName(localName), FullyQualifiedName(fullyQualifiedName))
+}
+
+case class WomIdentifier(localName: LocalName, fullyQualifiedName: FullyQualifiedName) {
+  def combine(other: String): WomIdentifier = {
+    WomIdentifier(localName.combineToLocalName(other), fullyQualifiedName.combine(other))
+  }
+}

--- a/wom/src/main/scala/wom/graph/WomIdentifier.scala
+++ b/wom/src/main/scala/wom/graph/WomIdentifier.scala
@@ -12,11 +12,12 @@ case class LocalName(private val value: String) {
 }
 
 /**
-  * Identifies a node uniquely in its graph.
+  * Identifies a node in its graph.
+  * It must be unique for all CallNodes, GraphInputNodes and GraphOutputNodes within a graph.
+  * Otherwise the Graph won't validate.
   * This *can* be the same as local name.
   * It is not required by WOM strictly speaking but rather useful to implementations
   * for serializing or reporting.
-  * A graph will fail to construct if two or more nodes share the same FullyQualifiedName
   */
 case class FullyQualifiedName(private val value: String) {
   def asString: String = value

--- a/wom/src/test/scala/wdl/wom/WdlAliasWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlAliasWomSpec.scala
@@ -38,13 +38,15 @@ class WdlAliasWomSpec extends FlatSpec with Matchers {
 
       val inputNodes: Set[ExternalGraphInputNode] = workflowGraph.nodes.filterByType[ExternalGraphInputNode]
       inputNodes.map(_.name) should be(Set("foo1.i", "foo2.i"))
-      inputNodes.map(_.fullyQualifiedIdentifier) should be(Set("conditional_test.foo1.i", "conditional_test.foo2.i"))
+      inputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("conditional_test.foo1.i", "conditional_test.foo2.i"))
 
       val callNodes: Set[CallNode] = workflowGraph.nodes.filterByType[CallNode]
       callNodes.map(_.name) should be(Set("foo1", "foo2"))
+      callNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("conditional_test.foo1", "conditional_test.foo2"))
 
       val outputNodes: Set[GraphOutputNode] = workflowGraph.nodes.filterByType[GraphOutputNode]
       outputNodes.map(_.name) should be(Set("foo1.out", "foo2.out"))
+      outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("conditional_test.foo1.out", "conditional_test.foo2.out"))
 
       workflowGraph.nodes.size should be(6)
     }

--- a/wom/src/test/scala/wdl/wom/WdlAliasWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlAliasWomSpec.scala
@@ -37,16 +37,16 @@ class WdlAliasWomSpec extends FlatSpec with Matchers {
     def validateGraph(workflowGraph: Graph) = {
 
       val inputNodes: Set[ExternalGraphInputNode] = workflowGraph.nodes.filterByType[ExternalGraphInputNode]
-      inputNodes.map(_.name) should be(Set("foo1.i", "foo2.i"))
-      inputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("conditional_test.foo1.i", "conditional_test.foo2.i"))
+      inputNodes.map(_.localName) should be(Set("foo1.i", "foo2.i"))
+      inputNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("conditional_test.foo1.i", "conditional_test.foo2.i"))
 
       val callNodes: Set[CallNode] = workflowGraph.nodes.filterByType[CallNode]
-      callNodes.map(_.name) should be(Set("foo1", "foo2"))
-      callNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("conditional_test.foo1", "conditional_test.foo2"))
+      callNodes.map(_.localName) should be(Set("foo1", "foo2"))
+      callNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("conditional_test.foo1", "conditional_test.foo2"))
 
       val outputNodes: Set[GraphOutputNode] = workflowGraph.nodes.filterByType[GraphOutputNode]
-      outputNodes.map(_.name) should be(Set("foo1.out", "foo2.out"))
-      outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("conditional_test.foo1.out", "conditional_test.foo2.out"))
+      outputNodes.map(_.localName) should be(Set("foo1.out", "foo2.out"))
+      outputNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("conditional_test.foo1.out", "conditional_test.foo2.out"))
 
       workflowGraph.nodes.size should be(6)
     }

--- a/wom/src/test/scala/wdl/wom/WdlConditionalWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlConditionalWomSpec.scala
@@ -55,6 +55,7 @@ class WdlConditionalWomSpec extends FlatSpec with Matchers {
           case gon: GraphOutputNode if gon.name == "foo.out" => gon
         }.getOrElse(fail("Resulting graph did not contain the 'foo.out' GraphOutputNode"))
         foo_out_output.womType should be(WdlOptionalType(WdlStringType))
+        foo_out_output.identifier.fullyQualifiedName.asString shouldBe "conditional_test.foo.out"
         
         val expressionNode = workflowGraph.nodes.collectFirst {
           case expr: ExpressionNode if expr.name == "conditional" => expr
@@ -67,12 +68,14 @@ class WdlConditionalWomSpec extends FlatSpec with Matchers {
       case class InnerGraphValidations(foo_out_innerOutput: GraphOutputNode)
       def validateInnerGraph(validatedOuterGraph: OuterGraphValidations): InnerGraphValidations = {
         val foo_i_innerInput = validatedOuterGraph.conditionalNode.innerGraph.nodes.collectFirst {
-          case gin: ExternalGraphInputNode if gin.fullyQualifiedIdentifier == "conditional_test.foo.i" => gin
+          case gin: ExternalGraphInputNode if gin.identifier.fullyQualifiedName.asString == "conditional_test.foo.i" => gin
         }.getOrElse(fail("Conditional inner graph did not contain a GraphInputNode 'foo.i'"))
 
         val foo_callNode = validatedOuterGraph.conditionalNode.innerGraph.nodes.collectFirst {
           case c: TaskCallNode if c.name == "foo" => c
         }.getOrElse(fail("Conditional inner graph did not contain a call to 'foo'"))
+
+        foo_callNode.identifier.fullyQualifiedName.asString shouldBe "conditional_test.foo"
 
         val foo_out_innerOutput = validatedOuterGraph.conditionalNode.innerGraph.nodes.collectFirst {
           case gon: GraphOutputNode if gon.name == "foo.out" => gon

--- a/wom/src/test/scala/wdl/wom/WdlConditionalWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlConditionalWomSpec.scala
@@ -46,19 +46,19 @@ class WdlConditionalWomSpec extends FlatSpec with Matchers {
 
         val inputNodes: Set[GraphInputNode] = workflowGraph.nodes.filterByType[GraphInputNode]
 
-        val b_inputNode = inputNodes.find(_.name == "b").getOrElse(fail("Resulting graph did not contain the 'b' GraphInputNode"))
+        val b_inputNode = inputNodes.find(_.localName == "b").getOrElse(fail("Resulting graph did not contain the 'b' GraphInputNode"))
         b_inputNode.womType should be(WdlBooleanType)
-        val foo_i_inputNode = inputNodes.find(_.name == "foo.i").getOrElse(fail("Resulting graph did not contain the 'foo.i' GraphInputNode"))
+        val foo_i_inputNode = inputNodes.find(_.localName == "foo.i").getOrElse(fail("Resulting graph did not contain the 'foo.i' GraphInputNode"))
         foo_i_inputNode.womType should be(WdlIntegerType)
 
         val foo_out_output = workflowGraph.nodes.collectFirst {
-          case gon: GraphOutputNode if gon.name == "foo.out" => gon
+          case gon: GraphOutputNode if gon.localName == "foo.out" => gon
         }.getOrElse(fail("Resulting graph did not contain the 'foo.out' GraphOutputNode"))
         foo_out_output.womType should be(WdlOptionalType(WdlStringType))
-        foo_out_output.identifier.fullyQualifiedName.asString shouldBe "conditional_test.foo.out"
+        foo_out_output.identifier.fullyQualifiedName.value shouldBe "conditional_test.foo.out"
         
         val expressionNode = workflowGraph.nodes.collectFirst {
-          case expr: ExpressionNode if expr.name == "conditional" => expr
+          case expr: ExpressionNode if expr.localName == "conditional" => expr
         }.getOrElse(fail("Resulting graph did not contain the 'conditional' ExpressionNode"))
 
         workflowGraph.nodes should be(Set(conditionalNode, foo_i_inputNode, b_inputNode, foo_out_output, expressionNode))
@@ -68,17 +68,17 @@ class WdlConditionalWomSpec extends FlatSpec with Matchers {
       case class InnerGraphValidations(foo_out_innerOutput: GraphOutputNode)
       def validateInnerGraph(validatedOuterGraph: OuterGraphValidations): InnerGraphValidations = {
         val foo_i_innerInput = validatedOuterGraph.conditionalNode.innerGraph.nodes.collectFirst {
-          case gin: ExternalGraphInputNode if gin.identifier.fullyQualifiedName.asString == "conditional_test.foo.i" => gin
+          case gin: ExternalGraphInputNode if gin.identifier.fullyQualifiedName.value == "conditional_test.foo.i" => gin
         }.getOrElse(fail("Conditional inner graph did not contain a GraphInputNode 'foo.i'"))
 
         val foo_callNode = validatedOuterGraph.conditionalNode.innerGraph.nodes.collectFirst {
-          case c: TaskCallNode if c.name == "foo" => c
+          case c: TaskCallNode if c.localName == "foo" => c
         }.getOrElse(fail("Conditional inner graph did not contain a call to 'foo'"))
 
-        foo_callNode.identifier.fullyQualifiedName.asString shouldBe "conditional_test.foo"
+        foo_callNode.identifier.fullyQualifiedName.value shouldBe "conditional_test.foo"
 
         val foo_out_innerOutput = validatedOuterGraph.conditionalNode.innerGraph.nodes.collectFirst {
-          case gon: GraphOutputNode if gon.name == "foo.out" => gon
+          case gon: GraphOutputNode if gon.localName == "foo.out" => gon
         }.getOrElse(fail("Conditional inner graph did not contain a GraphOutputNode 'foo.out'"))
 
         validatedOuterGraph.conditionalNode.innerGraph.nodes should be(Set(foo_i_innerInput, foo_callNode, foo_out_innerOutput))

--- a/wom/src/test/scala/wdl/wom/WdlConditionalWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlConditionalWomSpec.scala
@@ -88,8 +88,8 @@ class WdlConditionalWomSpec extends FlatSpec with Matchers {
       def validateConnections(validatedOuterGraph: OuterGraphValidations, validatedInnerGraph: InnerGraphValidations) = {
         // The ConditionalNode's output port is correctly associated with the inner graph's GraphOutputNode:
         validatedOuterGraph.conditionalNode.conditionalOutputPorts.toList match {
-          case ConditionalOutputPort(name, womType, outputToGather, _) :: Nil =>
-            name should be("foo.out")
+          case (port @ ConditionalOutputPort(womType, outputToGather, _)) :: Nil =>
+            port.name should be("foo.out")
             womType should be(WdlOptionalType(WdlStringType))
             outputToGather eq validatedInnerGraph.foo_out_innerOutput should be(true)
           case other => fail("Expected exactly one output to be gathered in this conditional but got:" + other.mkString("\n", "\n", "\n"))

--- a/wom/src/test/scala/wdl/wom/WdlInputValidationSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlInputValidationSpec.scala
@@ -41,12 +41,12 @@ class WdlInputValidationSpec extends FlatSpec with Matchers with BeforeAndAfterA
     .getOrElse(fail("Failed to build a wom definition"))
     .graph.valueOr(errors => fail(s"Failed to build a wom graph: ${errors.toList.mkString(", ")}"))
 
-  val w1OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.w1").getOrElse(fail("Failed to find an input node for w1")).singleOutputPort
-  val w2OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.w2").getOrElse(fail("Failed to find an input node for w2")).singleOutputPort
-  val t1OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.t.t1").getOrElse(fail("Failed to find an input node for t1")).singleOutputPort
-  val t2OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.t.t2").getOrElse(fail("Failed to find an input node for t2")).singleOutputPort
-  val u1OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.u.t1").getOrElse(fail("Failed to find an input node for u1")).singleOutputPort
-  val u2OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.u.t2").getOrElse(fail("Failed to find an input node for u2")).singleOutputPort
+  val w1OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.w1").getOrElse(fail("Failed to find an input node for w1")).singleOutputPort
+  val w2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.w2").getOrElse(fail("Failed to find an input node for w2")).singleOutputPort
+  val t1OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.t.t1").getOrElse(fail("Failed to find an input node for t1")).singleOutputPort
+  val t2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.t.t2").getOrElse(fail("Failed to find an input node for t2")).singleOutputPort
+  val u1OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.u.t1").getOrElse(fail("Failed to find an input node for u1")).singleOutputPort
+  val u2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedName == "w.u.t2").getOrElse(fail("Failed to find an input node for u2")).singleOutputPort
 
   def validate(inputFile: String): Checked[ResolvedExecutableInputs] = {
     import lenthall.validation.Checked._

--- a/wom/src/test/scala/wdl/wom/WdlInputValidationSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlInputValidationSpec.scala
@@ -41,12 +41,12 @@ class WdlInputValidationSpec extends FlatSpec with Matchers with BeforeAndAfterA
     .getOrElse(fail("Failed to build a wom definition"))
     .graph.valueOr(errors => fail(s"Failed to build a wom graph: ${errors.toList.mkString(", ")}"))
 
-  val w1OutputPort = graph.externalInputNodes.find(_.fullyQualifiedIdentifier == "w.w1").getOrElse(fail("Failed to find an input node for w1")).singleOutputPort
-  val w2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedIdentifier == "w.w2").getOrElse(fail("Failed to find an input node for w2")).singleOutputPort
-  val t1OutputPort = graph.externalInputNodes.find(_.fullyQualifiedIdentifier == "w.t.t1").getOrElse(fail("Failed to find an input node for t1")).singleOutputPort
-  val t2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedIdentifier == "w.t.t2").getOrElse(fail("Failed to find an input node for t2")).singleOutputPort
-  val u1OutputPort = graph.externalInputNodes.find(_.fullyQualifiedIdentifier == "w.u.t1").getOrElse(fail("Failed to find an input node for u1")).singleOutputPort
-  val u2OutputPort = graph.externalInputNodes.find(_.fullyQualifiedIdentifier == "w.u.t2").getOrElse(fail("Failed to find an input node for u2")).singleOutputPort
+  val w1OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.w1").getOrElse(fail("Failed to find an input node for w1")).singleOutputPort
+  val w2OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.w2").getOrElse(fail("Failed to find an input node for w2")).singleOutputPort
+  val t1OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.t.t1").getOrElse(fail("Failed to find an input node for t1")).singleOutputPort
+  val t2OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.t.t2").getOrElse(fail("Failed to find an input node for t2")).singleOutputPort
+  val u1OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.u.t1").getOrElse(fail("Failed to find an input node for u1")).singleOutputPort
+  val u2OutputPort = graph.externalInputNodes.find(_.identifier.fullyQualifiedName.asString == "w.u.t2").getOrElse(fail("Failed to find an input node for u2")).singleOutputPort
 
   def validate(inputFile: String): Checked[ResolvedExecutableInputs] = {
     import lenthall.validation.Checked._

--- a/wom/src/test/scala/wdl/wom/WdlNamespaceWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlNamespaceWomSpec.scala
@@ -66,19 +66,19 @@ class WdlNamespaceWomSpec extends FlatSpec with Matchers {
     val graphInputNodes = workflowGraph.nodes collect { case gin: ExternalGraphInputNode => gin }
     graphInputNodes should have size 1
     val patternInputNode = graphInputNodes.head
-    patternInputNode.name should be("cgrep.pattern")
-    patternInputNode.identifier.fullyQualifiedName.asString should be("three_step.cgrep.pattern")
+    patternInputNode.localName should be("cgrep.pattern")
+    patternInputNode.fullyQualifiedName should be("three_step.cgrep.pattern")
 
-    workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.name } should be(Set("wc.count", "cgrep.count", "ps.procs"))
+    workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.localName } should be(Set("wc.count", "cgrep.count", "ps.procs"))
 
-    val ps: TaskCallNode = workflowGraph.nodes.collectFirst({ case ps: TaskCallNode if ps.name == "ps" => ps }).get
-    val cgrep: TaskCallNode = workflowGraph.nodes.collectFirst({ case cgrep: TaskCallNode if cgrep.name == "cgrep" => cgrep }).get
+    val ps: TaskCallNode = workflowGraph.nodes.collectFirst({ case ps: TaskCallNode if ps.localName == "ps" => ps }).get
+    val cgrep: TaskCallNode = workflowGraph.nodes.collectFirst({ case cgrep: TaskCallNode if cgrep.localName == "cgrep" => cgrep }).get
     val cgrepInFileExpression = {
-      workflowGraph.nodes.collectFirst({ case cgrepInFile: ExpressionNode if cgrepInFile.name == "cgrep.in_file" => cgrepInFile }).get
+      workflowGraph.nodes.collectFirst({ case cgrepInFile: ExpressionNode if cgrepInFile.localName == "cgrep.in_file" => cgrepInFile }).get
     }
-    val wc: TaskCallNode = workflowGraph.nodes.collectFirst({ case wc: TaskCallNode if wc.name == "wc" => wc }).get
+    val wc: TaskCallNode = workflowGraph.nodes.collectFirst({ case wc: TaskCallNode if wc.localName == "wc" => wc }).get
     val wcInFileExpression = {
-      workflowGraph.nodes.collectFirst({ case wcInFile: ExpressionNode if wcInFile.name == "wc.in_file" => wcInFile }).get
+      workflowGraph.nodes.collectFirst({ case wcInFile: ExpressionNode if wcInFile.localName == "wc.in_file" => wcInFile }).get
     }
 
     workflowGraph.nodes.filterByType[CallNode] should be(Set(ps, cgrep, wc))

--- a/wom/src/test/scala/wdl/wom/WdlNamespaceWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlNamespaceWomSpec.scala
@@ -67,18 +67,18 @@ class WdlNamespaceWomSpec extends FlatSpec with Matchers {
     graphInputNodes should have size 1
     val patternInputNode = graphInputNodes.head
     patternInputNode.name should be("cgrep.pattern")
-    patternInputNode.fullyQualifiedIdentifier should be("three_step.cgrep.pattern")
+    patternInputNode.identifier.fullyQualifiedName.asString should be("three_step.cgrep.pattern")
 
     workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.name } should be(Set("wc.count", "cgrep.count", "ps.procs"))
 
     val ps: TaskCallNode = workflowGraph.nodes.collectFirst({ case ps: TaskCallNode if ps.name == "ps" => ps }).get
     val cgrep: TaskCallNode = workflowGraph.nodes.collectFirst({ case cgrep: TaskCallNode if cgrep.name == "cgrep" => cgrep }).get
     val cgrepInFileExpression = {
-      workflowGraph.nodes.collectFirst({ case cgrepInFile: ExpressionNode if cgrepInFile.name == "three_step.cgrep.in_file" => cgrepInFile }).get
+      workflowGraph.nodes.collectFirst({ case cgrepInFile: ExpressionNode if cgrepInFile.name == "cgrep.in_file" => cgrepInFile }).get
     }
     val wc: TaskCallNode = workflowGraph.nodes.collectFirst({ case wc: TaskCallNode if wc.name == "wc" => wc }).get
     val wcInFileExpression = {
-      workflowGraph.nodes.collectFirst({ case wcInFile: ExpressionNode if wcInFile.name == "three_step.wc.in_file" => wcInFile }).get
+      workflowGraph.nodes.collectFirst({ case wcInFile: ExpressionNode if wcInFile.name == "wc.in_file" => wcInFile }).get
     }
 
     workflowGraph.nodes.filterByType[CallNode] should be(Set(ps, cgrep, wc))

--- a/wom/src/test/scala/wdl/wom/WdlScatterWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlScatterWomSpec.scala
@@ -95,8 +95,8 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
 
         // The ScatterNode's output port links to the inner graph's GraphOutputNode:
         validatedOuterGraph.scatterNode.outputMapping.toList match {
-          case ScatterGathererPort(name, womType, outputToGather, _) :: Nil =>
-            name should be("foo.out")
+          case (port @ ScatterGathererPort(womType, outputToGather, _)) :: Nil =>
+            port.name should be("foo.out")
             womType should be(WdlArrayType(WdlStringType))
             outputToGather eq validatedInnerGraph.foo_out_innerOutput should be(true)
           case other => fail("Expected exactly one output to be gathered in this scatter but got:" + other.mkString("\n", "\n", "\n"))

--- a/wom/src/test/scala/wdl/wom/WdlScatterWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlScatterWomSpec.scala
@@ -45,18 +45,18 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
         val scatterNode = workflowGraph.nodes.firstByType[ScatterNode].getOrElse(fail("Resulting graph did not contain a ScatterNode"))
 
         val xs_inputNode = workflowGraph.nodes.collectFirst {
-          case gin: GraphInputNode if gin.name == "xs" => gin
+          case gin: GraphInputNode if gin.localName == "xs" => gin
         }.getOrElse(fail("Resulting graph did not contain the 'xs' GraphInputNode"))
 
         val scatterExpressionNode = workflowGraph.nodes.collectFirst {
-          case expr: ExpressionNode if expr.name == "x" => expr
+          case expr: ExpressionNode if expr.localName == "x" => expr
         }.getOrElse(fail("Resulting graph did not contain the 'x' ExpressionNode"))
 
         val foo_out_output = workflowGraph.nodes.collectFirst {
-          case gon: GraphOutputNode if gon.name == "foo.out" => gon
+          case gon: GraphOutputNode if gon.localName == "foo.out" => gon
         }.getOrElse(fail("Resulting graph did not contain the 'foo.out' GraphOutputNode"))
         foo_out_output.womType should be(WdlArrayType(WdlStringType))
-        foo_out_output.identifier.fullyQualifiedName.asString shouldBe "scatter_test.foo.out"
+        foo_out_output.identifier.fullyQualifiedName.value shouldBe "scatter_test.foo.out"
 
         workflowGraph.nodes should be(Set(scatterNode, xs_inputNode, foo_out_output, scatterExpressionNode))
         OuterGraphValidations(scatterNode, xs_inputNode)
@@ -65,21 +65,21 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
       case class InnerGraphValidations(x_scatterCollectionInput: GraphInputNode, foo_out_innerOutput: GraphOutputNode)
       def validateInnerGraph(validatedOuterGraph: OuterGraphValidations): InnerGraphValidations = {
         val x_scatterCollectionInput = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
-          case gin: GraphInputNode if gin.name == "x" => gin
+          case gin: GraphInputNode if gin.localName == "x" => gin
         }.getOrElse(fail("Scatter inner graph did not contain a GraphInputNode 'x'"))
 
         val foo_callNode = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
-          case c: TaskCallNode if c.name == "foo" => c
+          case c: TaskCallNode if c.localName == "foo" => c
         }.getOrElse(fail("Scatter inner graph did not contain a call to 'foo'"))
         
-        foo_callNode.identifier.fullyQualifiedName.asString shouldBe "scatter_test.foo"
+        foo_callNode.identifier.fullyQualifiedName.value shouldBe "scatter_test.foo"
 
         val foo_out_innerOutput = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
-          case gon: GraphOutputNode if gon.name == "foo.out" => gon
+          case gon: GraphOutputNode if gon.localName == "foo.out" => gon
         }.getOrElse(fail("Scatter inner graph did not contain a GraphOutputNode 'foo.out'"))
 
         val foo_out_i_expressionNode = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
-          case expr: ExpressionNode if expr.name == "foo.i" => expr
+          case expr: ExpressionNode if expr.localName == "foo.i" => expr
         }.getOrElse(fail("Scatter inner graph did not contain a ExpressionNode 'scatter_test.foo.i'"))
 
         validatedOuterGraph.scatterNode.innerGraph.nodes should be(Set(x_scatterCollectionInput, foo_callNode, foo_out_innerOutput, foo_out_i_expressionNode))
@@ -185,8 +185,8 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
 
       // Find the inputs:
       val inputNodes: Set[ExternalGraphInputNode] = workflowGraph.nodes.filterByType[ExternalGraphInputNode]
-      inputNodes.map {_.name} should be(Set("foo.j"))
-      inputNodes.map {_.identifier.fullyQualifiedName.asString} should be(Set("scatter_test.foo.j"))
+      inputNodes.map {_.localName} should be(Set("foo.j"))
+      inputNodes.map {_.identifier.fullyQualifiedName.value} should be(Set("scatter_test.foo.j"))
 
       // Find that scatter:
       val scatterNode = workflowGraph.nodes.collectFirst {
@@ -194,15 +194,15 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
       }.getOrElse(fail("Resulting graph did not contain a ScatterNode"))
 
       val scatterInnerInputs: Set[ExternalGraphInputNode] = scatterNode.innerGraph.nodes.filterByType[ExternalGraphInputNode]
-      scatterInnerInputs map {_.identifier.fullyQualifiedName.asString} should be(Set("scatter_test.foo.j"))
+      scatterInnerInputs map {_.identifier.fullyQualifiedName.value} should be(Set("scatter_test.foo.j"))
       val scatterInnerItemInput: Set[OuterGraphInputNode] = scatterNode.innerGraph.nodes.filterByType[OuterGraphInputNode]
-      scatterInnerItemInput map {_.name} should be(Set("s"))
+      scatterInnerItemInput map {_.localName} should be(Set("s"))
 
       // Find the outputs:
       val outputNodes = workflowGraph.nodes.collect {
         case output: GraphOutputNode => output
       }
-      outputNodes map { on => (on.name, on.womType) } should be(Set(("foo.int_out", WdlArrayType(WdlIntegerType)), ("foo.str_out", WdlArrayType(WdlStringType))))
+      outputNodes map { on => (on.localName, on.womType) } should be(Set(("foo.int_out", WdlArrayType(WdlIntegerType)), ("foo.str_out", WdlArrayType(WdlStringType))))
 
     }
   }

--- a/wom/src/test/scala/wdl/wom/WdlScatterWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlScatterWomSpec.scala
@@ -56,6 +56,7 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
           case gon: GraphOutputNode if gon.name == "foo.out" => gon
         }.getOrElse(fail("Resulting graph did not contain the 'foo.out' GraphOutputNode"))
         foo_out_output.womType should be(WdlArrayType(WdlStringType))
+        foo_out_output.identifier.fullyQualifiedName.asString shouldBe "scatter_test.foo.out"
 
         workflowGraph.nodes should be(Set(scatterNode, xs_inputNode, foo_out_output, scatterExpressionNode))
         OuterGraphValidations(scatterNode, xs_inputNode)
@@ -70,13 +71,15 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
         val foo_callNode = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
           case c: TaskCallNode if c.name == "foo" => c
         }.getOrElse(fail("Scatter inner graph did not contain a call to 'foo'"))
+        
+        foo_callNode.identifier.fullyQualifiedName.asString shouldBe "scatter_test.foo"
 
         val foo_out_innerOutput = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
           case gon: GraphOutputNode if gon.name == "foo.out" => gon
         }.getOrElse(fail("Scatter inner graph did not contain a GraphOutputNode 'foo.out'"))
 
         val foo_out_i_expressionNode = validatedOuterGraph.scatterNode.innerGraph.nodes.collectFirst {
-          case expr: ExpressionNode if expr.name == "scatter_test.foo.i" => expr
+          case expr: ExpressionNode if expr.name == "foo.i" => expr
         }.getOrElse(fail("Scatter inner graph did not contain a ExpressionNode 'scatter_test.foo.i'"))
 
         validatedOuterGraph.scatterNode.innerGraph.nodes should be(Set(x_scatterCollectionInput, foo_callNode, foo_out_innerOutput, foo_out_i_expressionNode))
@@ -183,7 +186,7 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
       // Find the inputs:
       val inputNodes: Set[ExternalGraphInputNode] = workflowGraph.nodes.filterByType[ExternalGraphInputNode]
       inputNodes.map {_.name} should be(Set("foo.j"))
-      inputNodes.map {_.fullyQualifiedIdentifier} should be(Set("scatter_test.foo.j"))
+      inputNodes.map {_.identifier.fullyQualifiedName.asString} should be(Set("scatter_test.foo.j"))
 
       // Find that scatter:
       val scatterNode = workflowGraph.nodes.collectFirst {
@@ -191,7 +194,7 @@ class WdlScatterWomSpec extends FlatSpec with Matchers {
       }.getOrElse(fail("Resulting graph did not contain a ScatterNode"))
 
       val scatterInnerInputs: Set[ExternalGraphInputNode] = scatterNode.innerGraph.nodes.filterByType[ExternalGraphInputNode]
-      scatterInnerInputs map {_.fullyQualifiedIdentifier} should be(Set("scatter_test.foo.j"))
+      scatterInnerInputs map {_.identifier.fullyQualifiedName.asString} should be(Set("scatter_test.foo.j"))
       val scatterInnerItemInput: Set[OuterGraphInputNode] = scatterNode.innerGraph.nodes.filterByType[OuterGraphInputNode]
       scatterInnerItemInput map {_.name} should be(Set("s"))
 

--- a/wom/src/test/scala/wdl/wom/WdlSubworkflowWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlSubworkflowWomSpec.scala
@@ -61,19 +61,19 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
 
     def validateOuter(workflowGraph: Graph) = {
       // One input, x
-      workflowGraph.inputNodes.map(_.name) should be(Set("x"))
+      workflowGraph.inputNodes.map(_.localName) should be(Set("x"))
       val calls = workflowGraph.calls
-      calls.map(_.name) should be(Set("inner"))
+      calls.map(_.localName) should be(Set("inner"))
 
       // One workflow call, "inner"
       val innerCall = calls.head.asInstanceOf[WorkflowCallNode]
-      innerCall.name should be("inner")
-      innerCall.identifier.fullyQualifiedName.asString should be("outer.inner")
+      innerCall.localName should be("inner")
+      innerCall.identifier.fullyQualifiedName.value should be("outer.inner")
       innerCall.upstream.head.asInstanceOf[ExpressionNode].inputPorts.map(_.upstream.graphNode) should be(Set(workflowGraph.inputNodes.head))
 
       // One output, "out"
-      workflowGraph.outputNodes.map(_.name) should be(Set("out"))
-      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("outer.out"))
+      workflowGraph.outputNodes.map(_.localName) should be(Set("out"))
+      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("outer.out"))
       workflowGraph.outputNodes.head.womType should be(WdlMaybeEmptyArrayType(WdlStringType))
       workflowGraph.outputNodes.foreach(_.upstream should be(Set(innerCall)))
 
@@ -81,17 +81,17 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
     }
 
     def validateInner(innerGraph: Graph) = {
-      innerGraph.inputNodes.map(_.name) should be(Set("i"))
+      innerGraph.inputNodes.map(_.localName) should be(Set("i"))
       val calls = innerGraph.calls
-      calls.map(_.name) should be(Set("foo"))
+      calls.map(_.localName) should be(Set("foo"))
 
       val fooCall = calls.head.asInstanceOf[TaskCallNode]
       fooCall.upstream.head.asInstanceOf[ExpressionNode].inputPorts.map(_.upstream.graphNode) should be(Set(innerGraph.inputNodes.head))
 
-      innerGraph.outputNodes.map(_.name) should be(Set("out", "x"))
-      innerGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("inner.out", "inner.x"))
-      val outOutput = innerGraph.outputNodes.find(_.name == "out").get
-      val xOutput = innerGraph.outputNodes.find(_.name == "x").get
+      innerGraph.outputNodes.map(_.localName) should be(Set("out", "x"))
+      innerGraph.outputNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("inner.out", "inner.x"))
+      val outOutput = innerGraph.outputNodes.find(_.localName == "out").get
+      val xOutput = innerGraph.outputNodes.find(_.localName == "x").get
 
       outOutput.womType should be(WdlStringType)
       outOutput.upstream should be(Set(fooCall))
@@ -152,15 +152,15 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
     }
 
     def validateOuter(workflowGraph: Graph) = {
-      workflowGraph.inputNodes.map(_.name) should be(Set("xs"))
+      workflowGraph.inputNodes.map(_.localName) should be(Set("xs"))
 
       val scatter = workflowGraph.scatters.head
       scatter.upstream should be(Set(workflowGraph.inputNodes.head))
       scatter.outputPorts.map(_.name) should be(Set("inner.out"))
       scatter.outputPorts.head.womType should be(WdlArrayType(WdlStringType))
 
-      workflowGraph.outputNodes.map(_.name) should be(Set("outs"))
-      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("outer.outs"))
+      workflowGraph.outputNodes.map(_.localName) should be(Set("outs"))
+      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("outer.outs"))
       workflowGraph.outputNodes.head.womType should be(WdlArrayType(WdlStringType))
       workflowGraph.outputNodes.foreach(_.upstream should be(Set(scatter)))
     }
@@ -217,16 +217,16 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       // One input, x
       workflowGraph.inputNodes shouldBe empty
       val calls = workflowGraph.calls
-      calls.map(_.name) should be(Set("twin"))
+      calls.map(_.localName) should be(Set("twin"))
 
       // One workflow call, "twin"
       val innerCall = calls.head.asInstanceOf[WorkflowCallNode]
-      innerCall.name should be("twin")
-      innerCall.identifier.fullyQualifiedName.asString should be("twin.twin")
+      innerCall.localName should be("twin")
+      innerCall.identifier.fullyQualifiedName.value should be("twin.twin")
 
       // One output, "out"
-      workflowGraph.outputNodes.map(_.name) should be(Set("outs"))
-      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("twin.outs"))
+      workflowGraph.outputNodes.map(_.localName) should be(Set("outs"))
+      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("twin.outs"))
       workflowGraph.outputNodes.head.womType should be(WdlStringType)
       workflowGraph.outputNodes.foreach(_.upstream should be(Set(innerCall)))
 
@@ -234,16 +234,16 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
     }
 
     def validateInner(innerGraph: Graph) = {
-      innerGraph.inputNodes.map(_.name) should be(Set("i"))
+      innerGraph.inputNodes.map(_.localName) should be(Set("i"))
       val calls = innerGraph.calls
-      calls.map(_.name) should be(Set("foo"))
+      calls.map(_.localName) should be(Set("foo"))
 
       val fooCall = calls.head.asInstanceOf[TaskCallNode]
       fooCall.upstream.head.asInstanceOf[ExpressionNode].inputPorts.map(_.upstream.graphNode) should be(Set(innerGraph.inputNodes.head))
 
-      innerGraph.outputNodes.map(_.name) should be(Set("out"))
-      innerGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("twin.out"))
-      val outOutput = innerGraph.outputNodes.find(_.name == "out").get
+      innerGraph.outputNodes.map(_.localName) should be(Set("out"))
+      innerGraph.outputNodes.map(_.identifier.fullyQualifiedName.value) should be(Set("twin.out"))
+      val outOutput = innerGraph.outputNodes.find(_.localName == "out").get
 
       outOutput.womType should be(WdlStringType)
       outOutput.upstream should be(Set(fooCall))

--- a/wom/src/test/scala/wdl/wom/WdlSubworkflowWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlSubworkflowWomSpec.scala
@@ -2,7 +2,7 @@ package wdl.wom
 
 import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.{FlatSpec, Matchers}
-import wdl.types.{WdlArrayType, WdlIntegerType, WdlStringType}
+import wdl.types.{WdlArrayType, WdlIntegerType, WdlMaybeEmptyArrayType, WdlStringType}
 import wdl.{ImportResolver, WdlNamespace, WdlNamespaceWithWorkflow}
 import wom.graph.{ExpressionNode, Graph, TaskCallNode, WorkflowCallNode}
 
@@ -68,11 +68,13 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       // One workflow call, "inner"
       val innerCall = calls.head.asInstanceOf[WorkflowCallNode]
       innerCall.name should be("inner")
+      innerCall.identifier.fullyQualifiedName.asString should be("outer.inner")
       innerCall.upstream.head.asInstanceOf[ExpressionNode].inputPorts.map(_.upstream.graphNode) should be(Set(workflowGraph.inputNodes.head))
 
       // One output, "out"
       workflowGraph.outputNodes.map(_.name) should be(Set("out"))
-      workflowGraph.outputNodes.head.womType should be(WdlStringType)
+      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("outer.out"))
+      workflowGraph.outputNodes.head.womType should be(WdlMaybeEmptyArrayType(WdlStringType))
       workflowGraph.outputNodes.foreach(_.upstream should be(Set(innerCall)))
 
       validateInner(innerCall.callable.innerGraph)
@@ -87,6 +89,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       fooCall.upstream.head.asInstanceOf[ExpressionNode].inputPorts.map(_.upstream.graphNode) should be(Set(innerGraph.inputNodes.head))
 
       innerGraph.outputNodes.map(_.name) should be(Set("out", "x"))
+      innerGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("inner.out", "inner.x"))
       val outOutput = innerGraph.outputNodes.find(_.name == "out").get
       val xOutput = innerGraph.outputNodes.find(_.name == "x").get
 
@@ -157,8 +160,93 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       scatter.outputPorts.head.womType should be(WdlArrayType(WdlStringType))
 
       workflowGraph.outputNodes.map(_.name) should be(Set("outs"))
+      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("outer.outs"))
       workflowGraph.outputNodes.head.womType should be(WdlArrayType(WdlStringType))
       workflowGraph.outputNodes.foreach(_.upstream should be(Set(scatter)))
+    }
+  }
+  
+  it should "support conversion of sub workflows with identical names" in {
+    val outerWdl =
+      """import "import_me.wdl" as import_me
+        |
+        |workflow twin {
+        |  Int i = 5
+        |  call import_me.twin { input: i = i }
+        |  output {
+        |    String outs = twin.out
+        |  }
+        |}""".stripMargin
+
+    val innerWdl =
+      """task foo {
+        |  Int i
+        |  command {
+        |    echo ${i}
+        |  }
+        |  output {
+        |    String out = read_string(stdout())
+        |  }
+        |}
+        |
+        |workflow twin {
+        |  Int i
+        |  call foo { input: i = i }
+        |  output {
+        |    String out = foo.out
+        |  }
+        |}
+      """.stripMargin
+
+    def innerResolver: ImportResolver = _ => innerWdl
+
+    val namespace = WdlNamespace.loadUsingSource(
+      workflowSource = outerWdl,
+      resource = None,
+      importResolver = Some(Seq(innerResolver))).get.asInstanceOf[WdlNamespaceWithWorkflow]
+
+    import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
+    val outerWorkflowGraph = namespace.workflow.womDefinition.flatMap(_.graph)
+
+    outerWorkflowGraph match {
+      case Valid(g) => validateOuter(g)
+      case Invalid(errors) => fail(s"Unable to build wom version of workflow with subworkflow from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
+    }
+
+    def validateOuter(workflowGraph: Graph) = {
+      // One input, x
+      workflowGraph.inputNodes shouldBe empty
+      val calls = workflowGraph.calls
+      calls.map(_.name) should be(Set("twin"))
+
+      // One workflow call, "twin"
+      val innerCall = calls.head.asInstanceOf[WorkflowCallNode]
+      innerCall.name should be("twin")
+      innerCall.identifier.fullyQualifiedName.asString should be("twin.twin")
+
+      // One output, "out"
+      workflowGraph.outputNodes.map(_.name) should be(Set("outs"))
+      workflowGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("twin.outs"))
+      workflowGraph.outputNodes.head.womType should be(WdlStringType)
+      workflowGraph.outputNodes.foreach(_.upstream should be(Set(innerCall)))
+
+      validateInner(innerCall.callable.innerGraph)
+    }
+
+    def validateInner(innerGraph: Graph) = {
+      innerGraph.inputNodes.map(_.name) should be(Set("i"))
+      val calls = innerGraph.calls
+      calls.map(_.name) should be(Set("foo"))
+
+      val fooCall = calls.head.asInstanceOf[TaskCallNode]
+      fooCall.upstream.head.asInstanceOf[ExpressionNode].inputPorts.map(_.upstream.graphNode) should be(Set(innerGraph.inputNodes.head))
+
+      innerGraph.outputNodes.map(_.name) should be(Set("out"))
+      innerGraph.outputNodes.map(_.identifier.fullyQualifiedName.asString) should be(Set("twin.out"))
+      val outOutput = innerGraph.outputNodes.find(_.name == "out").get
+
+      outOutput.womType should be(WdlStringType)
+      outOutput.upstream should be(Set(fooCall))
     }
   }
 

--- a/wom/src/test/scala/wdl/wom/WdlWomExpressionsAsInputsSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlWomExpressionsAsInputsSpec.scala
@@ -60,7 +60,7 @@ class WdlWomExpressionsAsInputsSpec extends FlatSpec with Matchers {
       case Invalid(errors) => fail(s"Unable to build wom graph from WDL: ${errors.toList.mkString("\n", "\n", "\n")}")
     }
 
-    val callNodes = workflowGraph.nodes.toList collect { case callNode: TaskCallNode => callNode.name -> callNode } toMap
+    val callNodes = workflowGraph.nodes.toList collect { case callNode: TaskCallNode => callNode.localName -> callNode } toMap
 
     val a = callNodes("a")
     val b = callNodes("b")
@@ -78,7 +78,7 @@ class WdlWomExpressionsAsInputsSpec extends FlatSpec with Matchers {
       val upstream = connectedInputPort.upstream
       upstream.name shouldBe "int_out"
       val upstreamTaskCallNode = upstream.graphNode.asInstanceOf[TaskCallNode]
-      upstreamTaskCallNode.name shouldBe x
+      upstreamTaskCallNode.localName shouldBe x
       // Instance equality test
       (upstreamTaskCallNode eq callNodes(x)) shouldBe true
     }

--- a/wom/src/test/scala/wom/callable/TaskDefinitionSpec.scala
+++ b/wom/src/test/scala/wom/callable/TaskDefinitionSpec.scala
@@ -3,7 +3,7 @@ package wom.callable
 import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.{FlatSpec, Matchers}
 import wdl.types.{WdlIntegerType, WdlStringType}
-import wom.graph.{CallNode, GraphInputNode, PortBasedGraphOutputNode}
+import wom.graph.{CallNode, GraphInputNode, LocalName, PortBasedGraphOutputNode}
 import wom.callable.TaskDefinitionSpec._
 
 class TaskDefinitionSpec extends FlatSpec with Matchers {
@@ -74,7 +74,7 @@ object TaskDefinitionSpec {
     meta = Map.empty,
     parameterMeta = Map.empty,
     outputs = List.empty,
-    inputs = List(Callable.RequiredInputDefinition("bar", WdlIntegerType)))
+    inputs = List(Callable.RequiredInputDefinition(LocalName("bar"), WdlIntegerType)))
 
   val oneOutputTask = TaskDefinition(
     name = "foo",
@@ -82,7 +82,7 @@ object TaskDefinitionSpec {
     runtimeAttributes = null,
     meta = Map.empty,
     parameterMeta = Map.empty,
-    outputs = List(Callable.OutputDefinition("bar", WdlStringType, null)),
+    outputs = List(Callable.OutputDefinition(LocalName("bar"), WdlStringType, null)),
     inputs = List.empty)
   
   val duplicateFqns = TaskDefinition(
@@ -91,7 +91,7 @@ object TaskDefinitionSpec {
     runtimeAttributes = null,
     meta = Map.empty,
     parameterMeta = Map.empty,
-    outputs = List(Callable.OutputDefinition("bar", WdlStringType, null)),
-    inputs = List(Callable.RequiredInputDefinition("bar", WdlStringType))
+    outputs = List(Callable.OutputDefinition(LocalName("bar"), WdlStringType, null)),
+    inputs = List(Callable.RequiredInputDefinition(LocalName("bar"), WdlStringType))
   )
 }

--- a/wom/src/test/scala/wom/callable/TaskDefinitionSpec.scala
+++ b/wom/src/test/scala/wom/callable/TaskDefinitionSpec.scala
@@ -47,6 +47,13 @@ class TaskDefinitionSpec extends FlatSpec with Matchers {
       case Invalid(l) => fail(s"Failed to construct a one-input TaskCall graph: ${l.toList.mkString(", ")}")
     }
   }
+  
+  it should "fail to build a graph with duplicates fqns" in {
+    duplicateFqns.graph match {
+      case Valid(_) => fail("The graph should be invalid")
+      case Invalid(_) =>
+    }
+  }
 }
 
 object TaskDefinitionSpec {
@@ -77,4 +84,14 @@ object TaskDefinitionSpec {
     parameterMeta = Map.empty,
     outputs = List(Callable.OutputDefinition("bar", WdlStringType, null)),
     inputs = List.empty)
+  
+  val duplicateFqns = TaskDefinition(
+    name = "foo",
+    commandTemplate = Seq.empty,
+    runtimeAttributes = null,
+    meta = Map.empty,
+    parameterMeta = Map.empty,
+    outputs = List(Callable.OutputDefinition("bar", WdlStringType, null)),
+    inputs = List(Callable.RequiredInputDefinition("bar", WdlStringType))
+  )
 }

--- a/wom/src/test/scala/wom/graph/ExpressionAsCallInputSpec.scala
+++ b/wom/src/test/scala/wom/graph/ExpressionAsCallInputSpec.scala
@@ -27,15 +27,15 @@ class ExpressionAsCallInputSpec extends FlatSpec with Matchers {
     */
   it should "create and wire in InstantiatedExpressions where appropriate" in {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode("i", WdlIntegerType)
-    val jInputNode = RequiredGraphInputNode("j", WdlIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WdlIntegerType)
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WdlIntegerType)
 
     // Declare an expression that needs both an "i" and a "j":
     val ijExpression = PlaceholderWomExpression(Set("i", "j"), WdlIntegerType)
 
     // Use that as an input to a one-input task:
     val expressionNode = ExpressionNode
-      .linkWithInputs("bar", ijExpression, Map("i" -> iInputNode.singleOutputPort, "j" -> jInputNode.singleOutputPort))
+      .linkWithInputs(WomIdentifier("bar"), ijExpression, Map("i" -> iInputNode.singleOutputPort, "j" -> jInputNode.singleOutputPort))
       .getOrElse(fail("Failed to build expression node"))
 
     val callNodeBuilder = new CallNodeBuilder()
@@ -49,7 +49,7 @@ class ExpressionAsCallInputSpec extends FlatSpec with Matchers {
     )
     
     val callNodeWithInputs = callNodeBuilder.build(
-      "foo",
+      WomIdentifier("foo"),
       TaskDefinitionSpec.oneInputTask,
       inputDefinitionFold
     )

--- a/wom/src/test/scala/wom/graph/ExpressionNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ExpressionNodeSpec.scala
@@ -46,13 +46,13 @@ class ExpressionNodeSpec extends FlatSpec with Matchers {
 
     def validate(graph: Graph) = {
       val x_outGraphOutputNode = graph.nodes.find {
-        case g: GraphOutputNode => g.name == "x_out"
+        case g: GraphOutputNode => g.localName == "x_out"
         case _ => false
       }.getOrElse(fail("No 'x_out' GraphOutputNode in the graph"))
 
       x_outGraphOutputNode.upstream.size should be(1)
       val xExpressionNode = x_outGraphOutputNode.upstream.head.asInstanceOf[ExpressionNode]
-      xExpressionNode.name should be("x")
+      xExpressionNode.localName should be("x")
       xExpressionNode.womType should be(WdlIntegerType)
 
       xExpressionNode.upstream should be(Set(iInputNode, jInputNode))

--- a/wom/src/test/scala/wom/graph/ExpressionNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ExpressionNodeSpec.scala
@@ -25,8 +25,8 @@ class ExpressionNodeSpec extends FlatSpec with Matchers {
     */
   it should "construct an ExpressionNode if inputs are available" in {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode("i", WdlIntegerType)
-    val jInputNode = RequiredGraphInputNode("j", WdlIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WdlIntegerType)
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WdlIntegerType)
 
     // Declare an expression that needs both an "i" and a "j":
     val ijExpression = PlaceholderWomExpression(Set("i", "j"), WdlIntegerType)
@@ -34,8 +34,8 @@ class ExpressionNodeSpec extends FlatSpec with Matchers {
     // Declare the expression node using both i and j:
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
     val graph = for {
-      xDeclarationNode <- ExpressionNode.linkWithInputs("x", ijExpression, Map("i" -> iInputNode.singleOutputPort, "j" -> jInputNode.singleOutputPort))
-      xOutputNode = PortBasedGraphOutputNode("x_out", WdlIntegerType, xDeclarationNode.singleExpressionOutputPort)
+      xDeclarationNode <- ExpressionNode.linkWithInputs(WomIdentifier("x"), ijExpression, Map("i" -> iInputNode.singleOutputPort, "j" -> jInputNode.singleOutputPort))
+      xOutputNode = PortBasedGraphOutputNode(WomIdentifier("x_out"), WdlIntegerType, xDeclarationNode.singleExpressionOutputPort)
       g <- Graph.validateAndConstruct(Set(iInputNode, jInputNode, xDeclarationNode, xOutputNode))
     } yield g
 

--- a/wom/src/test/scala/wom/graph/GraphOutputNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphOutputNodeSpec.scala
@@ -35,7 +35,7 @@ class GraphOutputNodeSpec extends FlatSpec with Matchers {
 
     def validate(graph: Graph) = {
       val expressionOutput = graph.nodes.find {
-        case g: GraphOutputNode => g.name == "x_out"
+        case g: GraphOutputNode => g.localName == "x_out"
         case _ => false
       }
 
@@ -43,7 +43,7 @@ class GraphOutputNodeSpec extends FlatSpec with Matchers {
       expressionOutput.get.upstream should be(Set(iInputNode, jInputNode))
 
       val portOutput = graph.nodes.find {
-        case g: GraphOutputNode => g.name == "j_out"
+        case g: GraphOutputNode => g.localName == "j_out"
         case _ => false
       }
 

--- a/wom/src/test/scala/wom/graph/GraphOutputNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphOutputNodeSpec.scala
@@ -2,7 +2,7 @@ package wom.graph
 
 import cats.data.Validated.{Invalid, Valid}
 import org.scalatest.{FlatSpec, Matchers}
-import wdl.types.WdlIntegerType
+import wdl.types.{WdlIntegerType, WdlStringType}
 import wom.expression._
 
 class GraphOutputNodeSpec extends FlatSpec with Matchers {
@@ -11,17 +11,17 @@ class GraphOutputNodeSpec extends FlatSpec with Matchers {
 
   it should "construct an ExpressionBasedGraphOutputNode node if inputs are available" in {
     // Two inputs:
-    val iInputNode = RequiredGraphInputNode("i", WdlIntegerType)
-    val jInputNode = RequiredGraphInputNode("j", WdlIntegerType)
+    val iInputNode = RequiredGraphInputNode(WomIdentifier("i"), WdlIntegerType)
+    val jInputNode = RequiredGraphInputNode(WomIdentifier("j"), WdlIntegerType)
 
     // Declare a port output from i:
-    val jOutput = PortBasedGraphOutputNode("j_out", WdlIntegerType, jInputNode.singleOutputPort)
+    val jOutput = PortBasedGraphOutputNode(WomIdentifier("j_out"), WdlIntegerType, jInputNode.singleOutputPort)
 
     // Declare an expression that needs both an "i" and a "j":
     val ijExpression = PlaceholderWomExpression(Set("i", "j"), WdlIntegerType)
 
     // Declare the expression output using both i and j:
-    val xOutputValidation = ExpressionBasedGraphOutputNode.linkWithInputs("x_out", ijExpression, Map(
+    val xOutputValidation = ExpressionBasedGraphOutputNode.linkWithInputs(WomIdentifier("x_out"), WdlStringType, ijExpression, Map(
       "i" -> iInputNode.singleOutputPort,
       "j" -> jInputNode.singleOutputPort))
 

--- a/wom/src/test/scala/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphSpec.scala
@@ -103,9 +103,9 @@ class GraphSpec extends FlatSpec with Matchers {
   it should "be able to represent three step" in {
     val workflowGraph = makeThreeStep
 
-    workflowGraph.nodes collect { case gin: GraphInputNode => gin.name } should be(Set("cgrep.pattern"))
-    workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.name } should be(Set("wc.count", "cgrep.count", "ps.procs"))
-    workflowGraph.nodes collect { case cn: CallNode => cn.name } should be(Set("wc", "cgrep", "ps"))
+    workflowGraph.nodes collect { case gin: GraphInputNode => gin.localName } should be(Set("cgrep.pattern"))
+    workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.localName } should be(Set("wc.count", "cgrep.count", "ps.procs"))
+    workflowGraph.nodes collect { case cn: CallNode => cn.localName } should be(Set("wc", "cgrep", "ps"))
   }
 
   it should "be able to represent calls to sub-workflows" in {
@@ -132,9 +132,9 @@ class GraphSpec extends FlatSpec with Matchers {
       case Invalid(errors) => fail(s"Unable to validate graph: ${errors.toList.mkString("\n", "\n", "\n")}")
     }
 
-    workflowGraph.nodes collect { case gin: GraphInputNode => gin.name } should be(Set("three_step.cgrep.pattern"))
-    workflowGraph.nodes collect { case gon: GraphOutputNode => gon.name } should be(Set("three_step.wc.count", "three_step.cgrep.count", "three_step.ps.procs"))
-    workflowGraph.nodes collect { case cn: CallNode => cn.name } should be(Set("three_step"))
+    workflowGraph.nodes collect { case gin: GraphInputNode => gin.localName } should be(Set("three_step.cgrep.pattern"))
+    workflowGraph.nodes collect { case gon: GraphOutputNode => gon.localName } should be(Set("three_step.wc.count", "three_step.cgrep.count", "three_step.ps.procs"))
+    workflowGraph.nodes collect { case cn: CallNode => cn.localName } should be(Set("three_step"))
   }
   
   it should "fail to validate a Graph with duplicate identifiers" in {

--- a/wom/src/test/scala/wom/graph/GraphSpec.scala
+++ b/wom/src/test/scala/wom/graph/GraphSpec.scala
@@ -48,11 +48,11 @@ class GraphSpec extends FlatSpec with Matchers {
       inputs = List(wcInFile)
     )
     
-    val workflowInputNode = RequiredGraphInputNode("cgrep.pattern", WdlStringType)
+    val workflowInputNode = RequiredGraphInputNode(WomIdentifier("cgrep.pattern"), WdlStringType)
     
     val psNodeBuilder = new CallNodeBuilder()
     
-    val CallNodeAndNewNodes(psCall, psGraphInputs, _) = psNodeBuilder.build("ps", taskDefinition_ps, InputDefinitionFold())
+    val CallNodeAndNewNodes(psCall, psGraphInputs, _) = psNodeBuilder.build(WomIdentifier("ps"), taskDefinition_ps, InputDefinitionFold())
     val ps_procsOutputPort = psCall.outputByName("procs").getOrElse(fail("Unexpectedly unable to find 'ps.procs' output"))
     
     val cgrepNodeBuilder = new CallNodeBuilder()
@@ -67,7 +67,7 @@ class GraphSpec extends FlatSpec with Matchers {
       ),
       Set(workflowInputNode)
     )
-    val CallNodeAndNewNodes(cgrepCall, cgrepGraphInputs, _) = cgrepNodeBuilder.build("cgrep", taskDefinition_cgrep, cgrepInputDefinitionFold)
+    val CallNodeAndNewNodes(cgrepCall, cgrepGraphInputs, _) = cgrepNodeBuilder.build(WomIdentifier("cgrep"), taskDefinition_cgrep, cgrepInputDefinitionFold)
     val cgrep_countOutputPort = cgrepCall.outputByName("count").getOrElse(fail("Unexpectedly unable to find 'cgrep.count' output"))
 
     val wcNodeBuilder = new CallNodeBuilder()
@@ -81,12 +81,12 @@ class GraphSpec extends FlatSpec with Matchers {
       Set.empty
     )
     
-    val CallNodeAndNewNodes(wcCall, wcGraphInputs, _) = wcNodeBuilder.build("wc", taskDefinition_wc, wcInputDefinitionFold)
+    val CallNodeAndNewNodes(wcCall, wcGraphInputs, _) = wcNodeBuilder.build(WomIdentifier("wc"), taskDefinition_wc, wcInputDefinitionFold)
     val wc_countOutputPort = wcCall.outputByName("count").getOrElse(fail("Unexpectedly unable to find 'wc.count' output"))
 
-    val psProcsOutputNode = PortBasedGraphOutputNode("ps.procs", WdlFileType, ps_procsOutputPort)
-    val cgrepCountOutputNode = PortBasedGraphOutputNode("cgrep.count", WdlIntegerType, cgrep_countOutputPort)
-    val wcCountOutputNode = PortBasedGraphOutputNode("wc.count", WdlIntegerType, wc_countOutputPort)
+    val psProcsOutputNode = PortBasedGraphOutputNode(WomIdentifier("ps.procs"), WdlFileType, ps_procsOutputPort)
+    val cgrepCountOutputNode = PortBasedGraphOutputNode(WomIdentifier("cgrep.count"), WdlIntegerType, cgrep_countOutputPort)
+    val wcCountOutputNode = PortBasedGraphOutputNode(WomIdentifier("wc.count"), WdlIntegerType, wc_countOutputPort)
 
     val graphNodes: Set[GraphNode] =
       Set[GraphNode](psCall, cgrepCall, wcCall, psProcsOutputNode, cgrepCountOutputNode, wcCountOutputNode)
@@ -113,19 +113,19 @@ class GraphSpec extends FlatSpec with Matchers {
     val threeStepWorkflow = WorkflowDefinition("three_step", threeStepGraph, Map.empty, Map.empty, List.empty)
     val threeStepNodeBuilder = new CallNodeBuilder()
 
-    val workflowInputNode = RequiredGraphInputNode("three_step.cgrep.pattern", WdlStringType)
+    val workflowInputNode = RequiredGraphInputNode(WomIdentifier("three_step.cgrep.pattern"), WdlStringType)
     
     val inputDefinitionFold = InputDefinitionFold(
       mappings = Map.empty,
       Set.empty,
       Set(workflowInputNode)
     )
-    val CallNodeAndNewNodes(threeStepCall, threeStepInputs, _) = threeStepNodeBuilder.build("three_step", threeStepWorkflow, inputDefinitionFold)
+    val CallNodeAndNewNodes(threeStepCall, threeStepInputs, _) = threeStepNodeBuilder.build(WomIdentifier("three_step"), threeStepWorkflow, inputDefinitionFold)
 
     // This is painful manually, but it's not up to WOM to decide which subworkflow outputs are forwarded through:
-    val psProcsOutputNode = PortBasedGraphOutputNode("three_step.ps.procs", WdlFileType, threeStepCall.outputByName("ps.procs").getOrElse(fail("Subworkflow didn't expose the ps.procs output")))
-    val cgrepCountOutputNode = PortBasedGraphOutputNode("three_step.cgrep.count", WdlIntegerType, threeStepCall.outputByName("cgrep.count").getOrElse(fail("Subworkflow didn't expose the cgrep.count output")))
-    val wcCountOutputNode = PortBasedGraphOutputNode("three_step.wc.count", WdlIntegerType, threeStepCall.outputByName("wc.count").getOrElse(fail("Subworkflow didn't expose the wc.count output")))
+    val psProcsOutputNode = PortBasedGraphOutputNode(WomIdentifier("three_step.ps.procs"), WdlFileType, threeStepCall.outputByName("ps.procs").getOrElse(fail("Subworkflow didn't expose the ps.procs output")))
+    val cgrepCountOutputNode = PortBasedGraphOutputNode(WomIdentifier("three_step.cgrep.count"), WdlIntegerType, threeStepCall.outputByName("cgrep.count").getOrElse(fail("Subworkflow didn't expose the cgrep.count output")))
+    val wcCountOutputNode = PortBasedGraphOutputNode(WomIdentifier("three_step.wc.count"), WdlIntegerType, threeStepCall.outputByName("wc.count").getOrElse(fail("Subworkflow didn't expose the wc.count output")))
 
     val workflowGraph = Graph.validateAndConstruct(Set[GraphNode](threeStepCall, psProcsOutputNode, cgrepCountOutputNode, wcCountOutputNode).union(threeStepInputs.toSet[GraphNode])) match {
       case Valid(wg) => wg
@@ -135,5 +135,20 @@ class GraphSpec extends FlatSpec with Matchers {
     workflowGraph.nodes collect { case gin: GraphInputNode => gin.name } should be(Set("three_step.cgrep.pattern"))
     workflowGraph.nodes collect { case gon: GraphOutputNode => gon.name } should be(Set("three_step.wc.count", "three_step.cgrep.count", "three_step.ps.procs"))
     workflowGraph.nodes collect { case cn: CallNode => cn.name } should be(Set("three_step"))
+  }
+  
+  it should "fail to validate a Graph with duplicate identifiers" in {
+    val nodeA = RequiredGraphInputNode(WomIdentifier("bar", "foo.bar"), WdlStringType)
+    val nodeB = RequiredGraphInputNode(WomIdentifier("bar", "foo.bar"), WdlIntegerType)
+    val nodeC = RequiredGraphInputNode(WomIdentifier("baz", "foo.baz"), WdlStringType)
+    val nodeD = RequiredGraphInputNode(WomIdentifier("baz", "foo.baz"), WdlIntegerType)
+    
+    Graph.validateAndConstruct(Set(nodeA, nodeB, nodeC, nodeD)) match {
+      case Valid(_) => fail("Graph should not validate")
+      case Invalid(errors) => errors.toList.toSet shouldBe Set(
+        "Two or more nodes have the same FullyQualifiedName: foo.baz",
+        "Two or more nodes have the same FullyQualifiedName: foo.bar"
+      )
+    }
   }
 }

--- a/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
@@ -47,14 +47,14 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
     *
     */
   it should "be able to wrap a single task call" in {
-    val xs_inputNode = RequiredGraphInputNode("xs", WdlArrayType(WdlIntegerType))
+    val xs_inputNode = RequiredGraphInputNode(WomIdentifier("xs"), WdlArrayType(WdlIntegerType))
 
     val xsExpression = PlaceholderWomExpression(Set("xs"), WdlArrayType(WdlIntegerType))
     val xsExpressionAsInput = ExpressionNode
-      .linkWithInputs("x", xsExpression, Map("xs" -> xs_inputNode.singleOutputPort))
+      .linkWithInputs(WomIdentifier("x"), xsExpression, Map("xs" -> xs_inputNode.singleOutputPort))
       .valueOr(failures => fail(s"Failed to create expression node: ${failures.toList.mkString(", ")}"))
     
-    val x_inputNode = OuterGraphInputNode("x", xsExpressionAsInput.singleExpressionOutputPort)
+    val x_inputNode = OuterGraphInputNode(WomIdentifier("x"), xsExpressionAsInput.singleExpressionOutputPort)
     val fooNodeBuilder = new CallNodeBuilder()
     val fooInputFold = InputDefinitionFold(
       mappings = Map(
@@ -65,8 +65,8 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
       ),
       newGraphInputNodes = Set.empty
     )
-    val CallNodeAndNewNodes(foo_callNode, _, _) = fooNodeBuilder.build("foo", task_foo, fooInputFold)
-    val foo_call_outNode = PortBasedGraphOutputNode("foo.out", WdlStringType, foo_callNode.outputByName("out").getOrElse(fail("foo CallNode didn't contain the expected 'out' output")))
+    val CallNodeAndNewNodes(foo_callNode, _, _) = fooNodeBuilder.build(WomIdentifier("foo"), task_foo, fooInputFold)
+    val foo_call_outNode = PortBasedGraphOutputNode(WomIdentifier("foo.out"), WdlStringType, foo_callNode.outputByName("out").getOrElse(fail("foo CallNode didn't contain the expected 'out' output")))
     val scatterGraph = Graph.validateAndConstruct(Set(foo_callNode, x_inputNode, foo_call_outNode)) match {
       case Valid(sg) => sg
       case Invalid(es) => fail("Failed to make scatter graph: " + es.toList.mkString(", "))
@@ -83,7 +83,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
     
     val workflowGraphValidation = for {
       foo_scatterOutput <- scatterNode.outputByName("foo.out")
-      z_workflowOutput = PortBasedGraphOutputNode("z", WdlArrayType(WdlStringType), foo_scatterOutput)
+      z_workflowOutput = PortBasedGraphOutputNode(WomIdentifier("z"), WdlArrayType(WdlStringType), foo_scatterOutput)
       graph <- Graph.validateAndConstruct(scatterNode.nodes ++ Set(xs_inputNode, z_workflowOutput))
     } yield graph
 

--- a/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
+++ b/wom/src/test/scala/wom/graph/ScatterNodeSpec.scala
@@ -96,9 +96,9 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
       * WDL -> WOM conversion has succeeded, now let's check we built it right!
       */
     def validate(workflowGraph: Graph, scatterNode: ScatterNode) = {
-      workflowGraph.nodes collect { case gin: GraphInputNode => gin.name } should be(Set("xs"))
-      workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.name } should be(Set("z"))
-      workflowGraph.nodes collect { case cn: CallNode => cn.name } should be(Set.empty)
+      workflowGraph.nodes collect { case gin: GraphInputNode => gin.localName } should be(Set("xs"))
+      workflowGraph.nodes collect { case gon: PortBasedGraphOutputNode => gon.localName } should be(Set("z"))
+      workflowGraph.nodes collect { case cn: CallNode => cn.localName } should be(Set.empty)
       (workflowGraph.nodes collect { case sn: ScatterNode => sn }).size should be(1)
 
       // The output links back to the scatter:
@@ -113,7 +113,7 @@ class ScatterNodeSpec extends FlatSpec with Matchers {
       innerGraphFooOutNode.womType should be(WdlStringType)
       innerGraphFooOutNode.upstream.size should be(1)
       innerGraphFooOutNode.upstream.head match {
-        case c: CallNode => c.name should be("foo")
+        case c: CallNode => c.localName should be("foo")
         case _ => fail("Expected the inner graph to have a Call Node!")
       }
     }


### PR DESCRIPTION
Replaces `name: String` by an `identifier: WomIdentifier` that contains both a `localName` and a `fullyQualifiedName`. This is not strictly speaking necessary for WOM but useful in Cromwell to uniquely identify nodes and for reporting. 
Naming suggestions for `LocalName` and `FullyQualifiedName` welcome :D

It needs some clean up but the main idea is there. Seagull at will