### PR TITLE
Improving type evaluation and lookup

### DIFF
--- a/wom/src/test/scala/wdl/DNAxTypeEvalTest.scala
+++ b/wom/src/test/scala/wdl/DNAxTypeEvalTest.scala
@@ -1,0 +1,182 @@
+package wdl
+
+import org.scalatest.{FlatSpec}
+import scala.util.{Failure, Success}
+import wdl.expression._
+import wdl.types._
+
+class DNAxTypeEvalTest extends FlatSpec {
+
+    val wdlCode =
+        """|task Add {
+           |  Int a
+           |  Int b
+           |
+           |  command {
+           |    echo $((${a} + ${b}))
+           |  }
+           |  output {
+           |    Int result = read_int(stdout())
+           |  }
+           |}
+           |
+           |workflow dict {
+           |  Map[Int, Int] mII = {1: 10, 2: 11}
+           |  Map[Int, Float]  mIF = {1: 1.2, 10: 113.0}
+           |
+           |  scatter(pair in mII) {
+           |    Int valueII = pair.right
+           |  }
+           |
+           |  scatter(pair in mIF) {
+           |    call Add {
+           |      input: a=pair.left, b=5
+           |    }
+           |  }
+           |
+           |  output {
+           |    valueII
+           |  }
+           |}
+           |""".stripMargin
+
+
+    // Figure out the type of an expression
+    def evalType(expr: WdlExpression, parent: Scope) : WdlType = {
+        expr.evaluateType(WdlNamespace.lookupType(parent),
+                          new WdlStandardLibraryFunctionsType,
+                          Some(parent)) match {
+            case Success(wdlType) => wdlType
+            case Failure(f) =>
+                System.err.println(s"could not evaluate type of expression ${expr.toWdlString}")
+                throw f
+        }
+    }
+
+    it should "correctly evaluate expression types" in {
+        val ns = WdlNamespaceWithWorkflow.load(wdlCode, Seq.empty).get
+        val wf = ns.workflow
+
+        val call:WdlCall = wf.findCallByName("Add") match {
+            case None => throw new Exception(s"Call Add not found in WDL file")
+            case Some(call) => call
+        }
+        val ssc:Scatter = wf.scatters.head
+
+        call.inputMappings.foreach { case (_, expr) =>
+            val t:WdlType = evalType(expr, ssc)
+            assert(t == WdlIntegerType)
+        }
+    }
+
+
+    val wdlCode2 =
+        """|task Copy {
+           |  File src
+           |  String basename
+           |
+           |  command <<<
+           |    cp ${src} ${basename}.txt
+           |    sort ${src} > ${basename}.sorted.txt
+           |  >>>
+           |  output {
+           |    File outf = "${basename}.txt"
+           |    File outf_sorted = "${basename}.sorted.txt"
+           |  }
+           |}
+           |
+           |
+           |workflow files {
+           |  File f
+           |
+           |  call Copy { input : src=f, basename="tearFrog" }
+           |  call Copy as Copy2 { input : src=Copy.outf, basename="mixing" }
+           |
+           |  output {
+           |    Copy2.outf_sorted
+           |  }
+           |}
+           |""".stripMargin
+
+    it should "correctly evaluate Strings and File types" in {
+        val ns = WdlNamespaceWithWorkflow.load(wdlCode2, Seq.empty).get
+        val wf = ns.workflow
+
+        val copy2call:WdlCall = wf.findCallByName("Copy2") match {
+            case None => throw new Exception(s"Call Add not found in WDL file")
+            case Some(call) => call
+        }
+
+        val e1 = copy2call.inputMappings("src")
+        val t1 = evalType(e1, copy2call)
+        //System.err.println(s"type(${e1.toWdlString}) = ${t1.toWdlString}")
+        assert(t1 == WdlFileType)
+
+        val e2 = copy2call.inputMappings("basename")
+        assert(evalType(e2, copy2call) == WdlStringType)
+    }
+
+
+    val wdlCode3 =
+    """|
+       |task Inc {
+       |  Int i
+       |
+       |  command <<<
+       |    python -c "print(${i} + 1)"
+       |  >>>
+       |  output {
+       |    Int result = read_int(stdout())
+       |  }
+       |}
+       |
+       |task Mod7 {
+       |  Int i
+       |
+       |  command <<<
+       |    python -c "print(${i} % 7)"
+       |  >>>
+       |  output {
+       |    Int result = read_int(stdout())
+       |  }
+       |}
+       |
+       |workflow math {
+       |  Int n = 5
+       |
+       |  scatter (k in range(length(n))) {
+       |    call Mod7 {input: i=k}
+       |  }
+       |
+       |  scatter (k in Mod7.result) {
+       |    call Inc {input: i=k}
+       |  }
+       |
+       |  output {
+       |    Inc.result
+       |  }
+       |}
+       |""".stripMargin
+
+    it should "take context into account" in {
+        val ns = WdlNamespaceWithWorkflow.load(wdlCode3, Seq.empty).get
+        val wf = ns.workflow
+
+        val incCall:WdlCall = wf.findCallByName("Inc") match {
+            case None => throw new Exception(s"Call Add not found in WDL file")
+            case Some(call) => call
+        }
+
+        val e1 = incCall.inputMappings("i")
+        val t1 = evalType(e1, incCall)
+        //System.err.println(s"type(${e1.toWdlString}) = ${t1.toWdlString}")
+        assert(t1 == WdlIntegerType)
+
+        val output = wf.outputs.head
+        //System.err.println(output)
+        val e2 = output.requiredExpression
+        val t2 = evalType(e2, wf)
+        //System.err.println(s"type(${e2.toWdlString}) = ${t2.toWdlString}")
+        assert(t2 == WdlMaybeEmptyArrayType(WdlIntegerType))
+    }
+}

--- a/wom/src/test/scala/wdl/wom/WdlSubworkflowWomSpec.scala
+++ b/wom/src/test/scala/wdl/wom/WdlSubworkflowWomSpec.scala
@@ -18,7 +18,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
         |  Int x
         |  call import_me.inner as inner { input: i = x }
         |  output {
-        |    Array[String] out = inner.out
+        |    Array[String] out = [inner.out]
         |  }
         |}""".stripMargin
 
@@ -51,7 +51,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       resource = None,
       importResolver = Some(Seq(innerResolver))).get.asInstanceOf[WdlNamespaceWithWorkflow]
     import lenthall.validation.ErrorOr.ShortCircuitingFlatMap
-    
+
     val outerWorkflowGraph = namespace.workflow.womDefinition.flatMap(_.graph)
 
     outerWorkflowGraph match {
@@ -165,7 +165,7 @@ class WdlSubworkflowWomSpec extends FlatSpec with Matchers {
       workflowGraph.outputNodes.foreach(_.upstream should be(Set(scatter)))
     }
   }
-  
+
   it should "support conversion of sub workflows with identical names" in {
     val outerWdl =
       """import "import_me.wdl" as import_me


### PR DESCRIPTION
I ran into some issues while using wdl4s inside the dxWDL compiler. I thought I would contribute upstream the fixes I came up with. Note that these fixes may be inaccurate. They pass the existing  tests, and the new test that I added. 

I ran the existing tests like this:
```testOnly wdl.*```

The test `wdl.wom.WdlSubworkflowWomSpec` was converting a String to an Array[String] automatically. Is this correct? I modified it, and added braces.

I hope this helps.  